### PR TITLE
Fix issue 45

### DIFF
--- a/plugins/modules/cs_template.py
+++ b/plugins/modules/cs_template.py
@@ -620,7 +620,7 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
             self.module.fail_json(msg="Failed: template not found")
 
         if self.module.params.get('cross_zones'):
-            self.module.warn('cross_zones parameter will be ignored for template extraction')
+            self.module.warn('cross_zones parameter is ignored when state is extracted')
 
         args = {
             'id': template['id'],

--- a/plugins/modules/cs_template.py
+++ b/plugins/modules/cs_template.py
@@ -619,6 +619,9 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
         if not template:
             self.module.fail_json(msg="Failed: template not found")
 
+        if self.module.params.get('cross_zones'):
+            self.module.warn('cross_zones parameter will be ignored for template extraction')
+
         args = {
             'id': template['id'],
             'url': self.module.params.get('url'),


### PR DESCRIPTION
it is possible to register a template for all zones, but not to extract it.

A minor PR to display a warning  in that particular case:

```
TASK [Wait for Template Registration] ******************************************************************************************
changed: [manager] => (item=debian-9-x86_64)
[WARNING]: cross_zones parameter is ignored when state is extracted

```
