### PR TITLE
WIP: Feature new inventory plugin

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,6 +1,8 @@
 name: Sanity
 on:
-- pull_request
+  schedule:
+  - cron: "* 12 * * *"
+  pull_request:
 
 jobs:
   sanity:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For existing Ansible roles, please also reference the full namespace, collection
 
 ### Plugins
 
-To use a pluign, please reference the full namespace, collection name, and plugins name that you want to use:
+To use a plugin, please reference the full namespace, collection name, and plugin name that you want to use:
 
 ```yaml
 plugin: ngine_io.cloudstack.cloudstack

--- a/changelogs/fragments/49-cs_instance-fix-keyerror.yml
+++ b/changelogs/fragments/49-cs_instance-fix-keyerror.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cs_instance - Fixed an edge case caused by `displaytext` not available (https://github.com/ngine-io/ansible-collection-cloudstack/pull/49).

--- a/changelogs/fragments/54-cs_network-fix-constraints.yml
+++ b/changelogs/fragments/54-cs_network-fix-constraints.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cs_network - Fix constraints when creating networks. The param `gateway` is no longer required if the param `netmask` is given (https://github.com/ngine-io/ansible-collection-cloudstack/pull/54).
+  - cs_network - Fixed constraints when creating networks. The param `gateway` is no longer required if the param `netmask` is given (https://github.com/ngine-io/ansible-collection-cloudstack/pull/54).

--- a/changelogs/fragments/54-cs_network-fix-constraints.yml
+++ b/changelogs/fragments/54-cs_network-fix-constraints.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cs_network - Fix constraints when creating networks. The param `gateway` is no longer required if the param `netmask` is given (https://github.com/ngine-io/ansible-collection-cloudstack/pull/54).

--- a/plugins/inventory/cloudstack.py
+++ b/plugins/inventory/cloudstack.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Rafael del valle <rafael@privaz.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import sys
+import os
+import traceback
+
+DOCUMENTATION = r'''
+    name: cloudstack
+    plugin_type: inventory
+    short_description: Apache CloudStack inventory source
+    author: Rafael del Valle (@rvalle)
+    version_added: 1.2.0
+    description:
+        - Get inventory hosts from Apache CloudStack
+        - Allows filtering and grouping inventory hosts.
+        - |
+            Uses an YAML configuration file ending with either I(cloudstack.yml) or I(cloudstack.yaml) 
+            to set parameter values (also see examples).
+    options:
+        plugin:
+            description: Token that ensures this is a source file for the 'cloudstack' plugin.
+            type: string
+            required: True
+            choices: [ cloudstack ]   
+    extends_documentation_fragment:
+        - ngine_io.cloudstack.cloudstack                 
+'''
+
+EXAMPLES = '''
+'''
+
+
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, AnsibleError
+from ansible.module_utils.basic import missing_required_lib
+from ..module_utils.cloudstack import HAS_LIB_CS, cs_get_api_config
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable):
+
+    NAME = 'ngine_io.cloudstack.cloudstack'
+
+    def __init__(self):
+        if not HAS_LIB_CS:
+            raise AnsibleError(missing_required_lib('cs'))
+
+    def get_api_config(self, path):
+
+        # this method will parse 'common format' inventory sources and
+        # update any options declared in DOCUMENTATION as needed
+        inventory_config = self._read_config_data(path)
+
+        api_config = cs_get_api_config(inventory_config)
+
+        return api_config
+
+    def verify_file(self, path):
+        """return true/false if this is possibly a valid file for this plugin to consume"""
+        valid = False
+        if super(InventoryModule, self).verify_file(path):
+            # base class verifies that file exists and is readable by current user
+            if path.endswith(('cloudstack.yaml', 'cloudstack.yml')):
+                valid = True
+        return valid
+
+    def parse(self, inventory, loader, path, cache=False):
+
+        # call base method to ensure properties are available for use with other helper methods
+        super(InventoryModule, self).parse(inventory, loader, path, cache)
+        api_config = self.get_api_config(path)
+
+        """# example consuming options from inventory source
+        mysession = apilib.session(user=self.get_option('api_user'),
+                                   password=self.get_option('api_pass'),
+                                   server=self.get_option('api_server')
+                                   )
+    
+        # make requests to get data to feed into inventory
+        mydata = mysession.getitall()"""
+
+        # parse data and create inventory objects:
+        """for colo in mydata:
+            for server in mydata[colo]['servers']:
+                self.inventory.add_host(server['name'])
+                self.inventory.set_variable(server['name'], 'ansible_host', server['external_ip'])"""
+
+        self.inventory.add_group('cloudstack')
+        self.inventory.add_host('hello_world')
+        self.inventory.set_variable('hello_world', 'ansible_host', '127.0.0.1')
+        self.inventory.add_child('cloudstack', 'hello_world')

--- a/plugins/inventory/cloudstack.py
+++ b/plugins/inventory/cloudstack.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, Rafael del valle <rafael@privaz.io>
@@ -44,7 +43,7 @@ DOCUMENTATION = r'''
             type: string
     extends_documentation_fragment:
         - constructed
-        - ngine_io.cloudstack.cloudstack            
+        - ngine_io.cloudstack.cloudstack
 '''
 
 EXAMPLES = '''

--- a/plugins/inventory/cloudstack.py
+++ b/plugins/inventory/cloudstack.py
@@ -58,6 +58,14 @@ instance:
   name: {{instance.instancename}}
   v4_main_ip: {{instance.nic[0].ipaddress}}
   hostname: {{instance.hostname | lower }}
+  zone: {{instance.zonename}}
+  template: {{instance.templatename}}
+  password_enabled: {{instance.passwordenabled}}
+  ha_enabled: {{instance.haenable}}
+  service_offering: {{instance.serviceofferingname}}
+  account: {{instance.account}}
+  domain: {{instance.domain | lower}}
+  hypervisor: {{instance.hypervisor | lower}}
 '''
 
 

--- a/plugins/inventory/cloudstack.py
+++ b/plugins/inventory/cloudstack.py
@@ -22,7 +22,7 @@ DOCUMENTATION = r'''
         - Get inventory hosts from Apache CloudStack
         - Allows filtering and grouping inventory hosts.
         - |
-            Uses an YAML configuration file ending with either I(cloudstack.yml) or I(cloudstack.yaml) 
+            Uses an YAML configuration file ending with either I(cloudstack.yml) or I(cloudstack.yaml)
             to set parameter values (also see examples).
     options:
         plugin:
@@ -32,7 +32,7 @@ DOCUMENTATION = r'''
             choices: [ cloudstack ]
         hostname:
             description: |
-                Field to match the hostname. Note v4_main_ip corresponds to the primary ipv4address of the first nic 
+                Field to match the hostname. Note v4_main_ip corresponds to the primary ipv4address of the first nic
                 adapter of the instance.
             type: string
             default: v4_main_ip
@@ -44,7 +44,7 @@ DOCUMENTATION = r'''
             type: string
     extends_documentation_fragment:
         - constructed
-        - ngine_io.cloudstack.cloudstack                 
+        - ngine_io.cloudstack.cloudstack            
 '''
 
 EXAMPLES = '''
@@ -89,7 +89,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         super().__init__()
         if not HAS_LIB_CS:
             raise AnsibleError(missing_required_lib('cs'))
-        self._cs=None
+        self._cs = None
         self._normalization_template = Template(INVENTORY_NORMALIZATION_J2)
 
     def init_cs(self, config):

--- a/plugins/module_utils/cloudstack.py
+++ b/plugins/module_utils/cloudstack.py
@@ -43,6 +43,30 @@ def cs_required_together():
     return [['api_key', 'api_secret']]
 
 
+def cs_get_api_config(params):
+    api_config_error = ''
+    api_region = params.get('api_region') or os.environ.get('CLOUDSTACK_REGION')
+    try:
+        config = read_config(api_region)
+    except (KeyError, SystemExit, ValueError) as e:
+        api_config_error = str(e)
+        config = {}
+
+    api_config = {
+        'endpoint': params.get('api_url') or config.get('endpoint'),
+        'key': params.get('api_key') or config.get('key'),
+        'secret': params.get('api_secret') or config.get('secret'),
+        'timeout': params.get('api_timeout') or config.get('timeout') or 10,
+        'method': params.get('api_http_method') or config.get('method') or 'get',
+        'verify': params.get('api_verify_ssl_cert') or config.get('verify'),
+    }
+
+    if not all([api_config['endpoint'], api_config['key'], api_config['secret']]):
+        raise SystemExit("Missing api credentials: can not authenticate. " + api_config_error)
+
+    return api_config
+
+
 class AnsibleCloudStack:
 
     def __init__(self, module):
@@ -114,20 +138,12 @@ class AnsibleCloudStack:
         return self._cs
 
     def get_api_config(self):
-        api_region = self.module.params.get('api_region') or os.environ.get('CLOUDSTACK_REGION')
         try:
-            config = read_config(api_region)
-        except (KeyError, SystemExit):
-            config = {}
+            api_config = cs_get_api_config(self.module.params)
+        except CloudStackException as e:
+            self.fail_json(msg=str(e))
 
-        api_config = {
-            'endpoint': self.module.params.get('api_url') or config.get('endpoint'),
-            'key': self.module.params.get('api_key') or config.get('key'),
-            'secret': self.module.params.get('api_secret') or config.get('secret'),
-            'timeout': self.module.params.get('api_timeout') or config.get('timeout') or 10,
-            'method': self.module.params.get('api_http_method') or config.get('method') or 'get',
-            'verify': self.module.params.get('api_verify_ssl_cert') or config.get('verify'),
-        }
+        api_region = self.module.params.get('api_region') or os.environ.get('CLOUDSTACK_REGION')
         self.result.update({
             'api_region': api_region,
             'api_url': api_config['endpoint'],
@@ -136,8 +152,7 @@ class AnsibleCloudStack:
             'api_http_method': api_config['method'],
             'api_verify_ssl_cert': api_config['verify'],
         })
-        if not all([api_config['endpoint'], api_config['key'], api_config['secret']]):
-            self.fail_json(msg="Missing api credentials: can not authenticate")
+
         return api_config
 
     def fail_json(self, **kwargs):

--- a/plugins/module_utils/cloudstack.py
+++ b/plugins/module_utils/cloudstack.py
@@ -117,7 +117,7 @@ class AnsibleCloudStack:
         api_region = self.module.params.get('api_region') or os.environ.get('CLOUDSTACK_REGION')
         try:
             config = read_config(api_region)
-        except KeyError:
+        except (KeyError, SystemExit):
             config = {}
 
         api_config = {

--- a/plugins/module_utils/cloudstack.py
+++ b/plugins/module_utils/cloudstack.py
@@ -62,7 +62,7 @@ def cs_get_api_config(params):
     }
 
     if not all([api_config['endpoint'], api_config['key'], api_config['secret']]):
-        raise SystemExit("Missing api credentials: can not authenticate. " + api_config_error)
+        raise ValueError("Missing api credentials: can not authenticate. " + api_config_error)
 
     return api_config
 
@@ -140,7 +140,7 @@ class AnsibleCloudStack:
     def get_api_config(self):
         try:
             api_config = cs_get_api_config(self.module.params)
-        except CloudStackException as e:
+        except ValueError as e:
             self.fail_json(msg=str(e))
 
         api_region = self.module.params.get('api_region') or os.environ.get('CLOUDSTACK_REGION')

--- a/plugins/modules/cs_disk_offering.py
+++ b/plugins/modules/cs_disk_offering.py
@@ -52,7 +52,6 @@ options:
     description:
       - Whether disk offering iops is custom or not.
     type: bool
-    default: no
   iops_read_rate:
     description:
       - IO requests read rate of the disk offering.

--- a/plugins/modules/cs_instance.py
+++ b/plugins/modules/cs_instance.py
@@ -494,7 +494,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             templates = self.query_api('listTemplates', **args)
             if templates:
                 for t in templates:
-                    if template in [t['displaytext'], t['name'], t['id']]:
+                    if template in [t.get('displaytext', None), t['name'], t['id']]:
                         if rootdisksize and t['size'] > rootdisksize * 1024 ** 3:
                             continue
                         self.template = t

--- a/plugins/modules/cs_network.py
+++ b/plugins/modules/cs_network.py
@@ -164,6 +164,15 @@ EXAMPLES = '''
     network_offering: DefaultIsolatedNetworkOfferingWithSourceNatService
     network_domain: example.com
 
+- name: Create a network with start and end IP
+  ngine_io.cloudstack.cs_network:
+    name: Private Network
+    network_offering: PrivNet
+    start_ip: 10.12.9.10
+    end_ip: 10.12.9.100
+    netmask: 255.255.255.0
+    zone: gva-01
+
 - name: Create a VPC tier
   ngine_io.cloudstack.cs_network:
     name: my VPC tier 1
@@ -597,14 +606,10 @@ def main():
         poll_async=dict(type='bool', default=True),
         tags=dict(type='list', elements='dict', aliases=['tag']),
     ))
-    required_together = cs_required_together()
-    required_together.extend([
-        ['netmask', 'gateway'],
-    ])
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_together=required_together,
+        required_together=cs_required_together(),
         supports_check_mode=True
     )
 

--- a/plugins/modules/cs_service_offering.py
+++ b/plugins/modules/cs_service_offering.py
@@ -116,7 +116,6 @@ options:
     description:
       - Whether HA is set for the service offering.
     type: bool
-    default: no
   provisioning_type:
     description:
       - Provisioning type used to create volumes.

--- a/tests/integration/targets/inventory_cloudstack/playbooks/basic-configuration.yml
+++ b/tests/integration/targets/inventory_cloudstack/playbooks/basic-configuration.yml
@@ -1,0 +1,22 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  vars:
+    simulator: http://cloudstack-sim:8888
+  tasks:
+    - name: Retrieve Simulator Keys
+      uri:
+        url: "{{simulator}}/admin.json"
+        return_content: yes
+      register: admin
+
+    - name: Create cloudstack.ini
+      template:
+        src: templates/cloudstack.ini.j2
+        dest: ../cloudstack.ini
+
+    - name: Create test.cloudstack.yml
+      template:
+        src: templates/inventory.cloudstack.yml.j2
+        dest: ../test.cloudstack.yml

--- a/tests/integration/targets/inventory_cloudstack/playbooks/cloudstack-inventory-test.yml
+++ b/tests/integration/targets/inventory_cloudstack/playbooks/cloudstack-inventory-test.yml
@@ -1,0 +1,4 @@
+---
+
+- import_playbook: basic-configuration.yml
+- import_playbook: common-cloudstack-objects.yml

--- a/tests/integration/targets/inventory_cloudstack/playbooks/common-cloudstack-objects.yml
+++ b/tests/integration/targets/inventory_cloudstack/playbooks/common-cloudstack-objects.yml
@@ -1,0 +1,31 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  tasks:
+
+    - include_vars:
+        file: vars/common.yml
+
+    - name: wait for system template available
+      cs_template:
+        name: "{{ cs_common_template }}"
+        state: absent
+        cross_zones: yes
+        template_filter: all
+      register: template
+      check_mode: true
+      until: template is changed
+      retries: 20
+      delay: 5
+
+    - name: smoke test instance
+      cs_instance:
+        name: smoke-test-vm
+        template: "{{ cs_common_template }}"
+        service_offering: "{{ cs_common_service_offering }}"
+        zone: "{{ cs_common_zone_adv }}"
+      register: instance
+      until: instance is successful
+      retries: 2
+      delay: 5

--- a/tests/integration/targets/inventory_cloudstack/playbooks/templates/cloudstack.ini.j2
+++ b/tests/integration/targets/inventory_cloudstack/playbooks/templates/cloudstack.ini.j2
@@ -1,0 +1,5 @@
+[cloudstack]
+endpoint = {{simulator}}/client/api
+key = {{admin.json.apikey}}
+secret = {{admin.json.secretkey}}
+timeout = 60

--- a/tests/integration/targets/inventory_cloudstack/playbooks/templates/inventory.cloudstack.yml.j2
+++ b/tests/integration/targets/inventory_cloudstack/playbooks/templates/inventory.cloudstack.yml.j2
@@ -1,0 +1,2 @@
+plugin: ngine_io.cloudstack.cloudstack
+

--- a/tests/integration/targets/inventory_cloudstack/playbooks/templates/inventory.cloudstack.yml.j2
+++ b/tests/integration/targets/inventory_cloudstack/playbooks/templates/inventory.cloudstack.yml.j2
@@ -1,2 +1,5 @@
 plugin: ngine_io.cloudstack.cloudstack
 
+keyed_groups:
+  - prefix: cs_zone
+    key: zone | lower

--- a/tests/integration/targets/inventory_cloudstack/playbooks/vars/common.yml
+++ b/tests/integration/targets/inventory_cloudstack/playbooks/vars/common.yml
@@ -1,0 +1,9 @@
+---
+
+# TODO: This is borrowed from common role, should be better reused
+
+cs_resource_prefix: "cs-{{ (ansible_date_time.iso8601_micro | to_uuid).split('-')[0] }}"
+cs_common_template: CentOS 5.6 (64-bit) no GUI (Simulator)
+cs_common_service_offering: Small Instance
+cs_common_zone_adv: Sandbox-simulator-advanced
+cs_common_zone_basic: Sandbox-simulator-basic

--- a/tests/integration/targets/inventory_cloudstack/runme.sh
+++ b/tests/integration/targets/inventory_cloudstack/runme.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eux
+env
+
+# Required to differentiate between Python 2 and 3 environ
+PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+
+# TODO: the test environment is bit setup when running this integration test on its own.
+${PYTHON} -m pip install cs
+
+export CLOUDSTACK_CONFIG=$(pwd)/cloudstack.ini
+
+# TODO: why is it looking for cloudstack conf section?
+ansible-playbook playbooks/cloudstack-inventory-test.yml "$@"
+
+ansible-inventory --list -i test.cloudstack.yml "$@"
+

--- a/tests/integration/targets/inventory_cloudstack/runme.sh
+++ b/tests/integration/targets/inventory_cloudstack/runme.sh
@@ -8,7 +8,8 @@ PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 # TODO: the test environment is bit setup when running this integration test on its own.
 ${PYTHON} -m pip install cs
 
-export CLOUDSTACK_CONFIG=$(pwd)/cloudstack.ini
+CLOUDSTACK_CONFIG=$(pwd)/cloudstack.ini
+export CLOUDSTACK_CONFIG
 
 # TODO: why is it looking for cloudstack conf section?
 ansible-playbook playbooks/cloudstack-inventory-test.yml "$@"

--- a/tests/integration/targets/inventory_cloudstack/test.cloudstack.yml
+++ b/tests/integration/targets/inventory_cloudstack/test.cloudstack.yml
@@ -1,0 +1,1 @@
+plugin: ngine_io.cloudstack.cloudstack

--- a/tests/unit/plugins/inventory/fixtures/cloudstack.ini
+++ b/tests/unit/plugins/inventory/fixtures/cloudstack.ini
@@ -1,4 +1,4 @@
-[default]
+[cloudstack]
 endpoint = http://localhost
 key = s7T2jkUw4lZNJd8d3931KuCDYcSS0TtbFDTZR-DQoL9-3jn_11UqE1LekwGXzPJLx87xF7nU-fi5yZzpDkOpIw
 secret = -wkrHErJnQdGH2-R0-AkkYMi3RGdA3k4cXjjiUF5MW320xJjkd__yGkAD4SOLIgAYbPTLhWS4PamTdYvXcnJQA

--- a/tests/unit/plugins/inventory/fixtures/cloudstack.ini
+++ b/tests/unit/plugins/inventory/fixtures/cloudstack.ini
@@ -1,0 +1,5 @@
+[default]
+endpoint = http://localhost
+key = s7T2jkUw4lZNJd8d3931KuCDYcSS0TtbFDTZR-DQoL9-3jn_11UqE1LekwGXzPJLx87xF7nU-fi5yZzpDkOpIw
+secret = -wkrHErJnQdGH2-R0-AkkYMi3RGdA3k4cXjjiUF5MW320xJjkd__yGkAD4SOLIgAYbPTLhWS4PamTdYvXcnJQA
+timeout = 60

--- a/tests/unit/plugins/inventory/fixtures/partial-cloudstack.ini
+++ b/tests/unit/plugins/inventory/fixtures/partial-cloudstack.ini
@@ -1,0 +1,4 @@
+[default]
+key = s7T2jkUw4lZNJd8d3931KuCDYcSS0TtbFDTZR-DQoL9-3jn_11UqE1LekwGXzPJLx87xF7nU-fi5yZzpDkOpIw
+secret = -wkrHErJnQdGH2-R0-AkkYMi3RGdA3k4cXjjiUF5MW320xJjkd__yGkAD4SOLIgAYbPTLhWS4PamTdYvXcnJQA
+timeout = 60

--- a/tests/unit/plugins/inventory/fixtures/partial-cloudstack.ini
+++ b/tests/unit/plugins/inventory/fixtures/partial-cloudstack.ini
@@ -1,4 +1,4 @@
-[default]
+[cloudstack]
 key = s7T2jkUw4lZNJd8d3931KuCDYcSS0TtbFDTZR-DQoL9-3jn_11UqE1LekwGXzPJLx87xF7nU-fi5yZzpDkOpIw
 secret = -wkrHErJnQdGH2-R0-AkkYMi3RGdA3k4cXjjiUF5MW320xJjkd__yGkAD4SOLIgAYbPTLhWS4PamTdYvXcnJQA
 timeout = 60

--- a/tests/unit/plugins/inventory/fixtures/test-configured.cloudstack.yml
+++ b/tests/unit/plugins/inventory/fixtures/test-configured.cloudstack.yml
@@ -1,0 +1,6 @@
+plugin: cloudstack
+
+api_url: http://localhost
+api_key: s7T2jkUw4lZNJd8d3931KuCDYcSS0TtbFDTZR-DQoL9-3jn_11UqE1LekwGXzPJLx87xF7nU-fi5yZzpDkOpIw
+api_secret: -wkrHErJnQdGH2-R0-AkkYMi3RGdA3k4cXjjiUF5MW320xJjkd__yGkAD4SOLIgAYbPTLhWS4PamTdYvXcnJQA
+api_timeout: 60

--- a/tests/unit/plugins/inventory/fixtures/test-not-configured.cloudstack.yml
+++ b/tests/unit/plugins/inventory/fixtures/test-not-configured.cloudstack.yml
@@ -1,0 +1,1 @@
+plugin: cloudstack

--- a/tests/unit/plugins/inventory/fixtures/wrong-inventory.ini
+++ b/tests/unit/plugins/inventory/fixtures/wrong-inventory.ini
@@ -1,0 +1,2 @@
+[other]
+hosts

--- a/tests/unit/plugins/inventory/test_cloudstack_inventory.py
+++ b/tests/unit/plugins/inventory/test_cloudstack_inventory.py
@@ -1,0 +1,76 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+import os
+
+from ansible.parsing.dataloader import DataLoader
+from plugins.inventory.cloudstack import InventoryModule
+
+
+class InventoryModuleMock(InventoryModule):
+    # Try to keep the InventoryModule clean without Unit Testing entry-points
+
+    def __init__(self):
+        super().__init__()
+        self.loader = DataLoader()
+        self._redirected_names = ['cloudstack']
+        self._load_name = self.NAME
+
+
+class InventoryTestCase(unittest.TestCase):
+
+    def tearDown(self):
+        # We clean up the cloudstack process environment after each test
+        # As different test use different configurations
+        for param in ['CONFIG', 'ENDPOINT', 'KEY', 'SECRET']:
+            env_param = "CLOUDSTACK_{}".format(param)
+            if env_param in os.environ:
+                os.environ.pop(env_param)
+
+    def test_invalid_existing_file(self):
+        # dummy test to get the environment setup
+        self.assertFalse(InventoryModuleMock().verify_file("fixtures/wrong-inventory.ini"))
+
+    def test_valid_file(self):
+        # dummy test to get the environment setup
+        self.assertTrue(InventoryModuleMock().verify_file("fixtures/test-not-configured.cloudstack.yml"))
+
+    def test_full_configured_inventory_plugin(self):
+        # We check that it is possible to configure all required settings in the inventory
+        # plugin file
+        api_config = InventoryModuleMock().get_api_config('fixtures/test-configured.cloudstack.yml')
+        self.assertTrue(all([api_config['endpoint'], api_config['key'], api_config['secret']]))
+
+    def test_missing_ini_configured_inventory_plugin(self):
+        # We check that if the ini file requested is missing and the plugin configuration
+        # file does not include connection parameters we get the right exception
+        # should include both missing params and missing ini file
+        with self.assertRaises(SystemExit) as cxt:
+            os.environ['CLOUDSTACK_CONFIG'] = 'fixtures/missing-cloudstack.ini'
+            InventoryModuleMock().get_api_config('fixtures/test-not-configured.cloudstack.yml')
+        self.assertIn('file not found', str(cxt.exception))
+        self.assertIn('Missing api credentials', str(cxt.exception))
+
+    def test_incomplete_ini_configured_inventory_plugin(self):
+        # We check that if ini is partially configured and plugin not configured we get
+        # message talking about missing keys
+        with self.assertRaises(SystemExit) as cxt:
+            os.environ['CLOUDSTACK_CONFIG'] = 'fixtures/partial-cloudstack.ini'
+            InventoryModuleMock().get_api_config('fixtures/test-not-configured.cloudstack.yml')
+        self.assertIn('missing the following keys', str(cxt.exception))
+
+    def test_environment_configuration_inventory_plugin(self):
+        # We check that when using a not configured inventory plugin file
+        # With environment variables providing the configuration a valid
+        # configuration is achieved
+        os.environ['CLOUDSTACK_CONFIG'] = 'fixtures/missing-cloudstack.ini'
+        os.environ['CLOUDSTACK_ENDPOINT'] = 'http://localhost'
+        os.environ['CLOUDSTACK_KEY'] = 'mykey'
+        os.environ['CLOUDSTACK_SECRET'] = 'mysecret'
+        api_config = InventoryModuleMock().get_api_config('fixtures/test-not-configured.cloudstack.yml')
+        self.assertTrue(all([api_config['endpoint'], api_config['key'], api_config['secret']]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/plugins/inventory/test_cloudstack_inventory.py
+++ b/tests/unit/plugins/inventory/test_cloudstack_inventory.py
@@ -30,7 +30,7 @@ class InventoryTestCase(unittest.TestCase):
         # We clean up the cloudstack process environment after each test
         # As different test use different configurations
         for param in ['CONFIG', 'ENDPOINT', 'KEY', 'SECRET']:
-            env_param = "CLOUDSTACK_{}".format(param)
+            env_param = "CLOUDSTACK_{setting}".format(setting=param)
             if env_param in os.environ:
                 os.environ.pop(env_param)
 


### PR DESCRIPTION
Working on the new inventory plug in, should fix #51 and #26 

This PR covers the following:

- Tries to integrate with the current cloudstack module_utils, not replicating code for: cs init, reading cs config, so there is a re-factorization of the AnsibleCloudstack base class. @resmo you need to review it.

- Tries to reuse the configuration_fragment used for the rest of the modules.

- Provides some unit tests mainly to validate all cases of #51, this are run manually.

- Provides an integration test (WIP) to check the inventory plugin itself. I am having my hardest time here, I can't find any documentation about how to do it properly, and not many examples out there. However the test is getting called and it seems possible to validate the plugin.

@resmo  I update this as WIP so that you can review and provide comments as finalize it.