### PR TITLE
Added project ID to volume query when checking root disk size.

### DIFF
--- a/plugins/modules/cs_instance.py
+++ b/plugins/modules/cs_instance.py
@@ -786,7 +786,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
         root_disk_size_changed = False
 
         if root_disk_size is not None:
-            res = self.query_api('listVolumes', type='ROOT', virtualmachineid=instance['id'])
+            res = self.query_api('listVolumes', type='ROOT', virtualmachineid=instance['id'], projectid=instance['projectid'])
             [volume] = res['volume']
 
             size = volume['size'] >> 30


### PR DESCRIPTION
At the moment, if specifying a size for a root drive of an instance, any attempt to rerun the playbook will fail on currently-deployed instances if the VM is deployed outside of the root project. This PR makes sure the volumes query is within the same project as the VM it's trying to determine the root volume size of.