### PR TITLE
Allow passing cluster and pod details when deploying an VM

### DIFF
--- a/plugins/modules/cs_instance.py
+++ b/plugins/modules/cs_instance.py
@@ -146,7 +146,7 @@ options:
       - Pod on which an instance should be deployed or started on.
       - Only considered when I(state=started) or instance is running.
       - Requires root admin privileges.
-    type: str 
+    type: str
   domain:
     description:
       - Domain the instance is related to.
@@ -499,7 +499,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             for c in clusters['cluster']:
                 if cluster_name in [c['name'], c['id']]:
                     return c['id']
-      
+
         self.fail_json(msg="Cluster '%s' not found" % cluster_name)
 
     def get_pod_id(self):
@@ -515,7 +515,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             for p in pods['pod']:
                 if pod_name in [p['name'], p['id']]:
                     return p['id']
-      
+
         self.fail_json(msg="Pod '%s' not found" % pod_name)
 
     def get_template_or_iso(self, key=None):

--- a/plugins/modules/cs_instance.py
+++ b/plugins/modules/cs_instance.py
@@ -481,42 +481,42 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
         hosts = self.query_api('listHosts', **args)
         if hosts:
             for h in hosts['host']:
-              if host_name in [h['name'], h['id']]:
-                return h['id']
+                if host_name in [h['name'], h['id']]:
+                    return h['id']
 
         self.fail_json(msg="Host '%s' not found" % host_name)
 
     def get_cluster_id(self):
-      cluster_name = self.module.params.get('cluster')
-      if not cluster_name:
-        return None
+        cluster_name = self.module.params.get('cluster')
+        if not cluster_name:
+            return None
 
-      args = {
-        'zoneid': self.get_zone(key='id')
-      }
-      clusters = self.query_api('listClusters', **args)
-      if clusters:
-        for c in clusters['cluster']:
-          if cluster_name in [c['name'], c['id']]:
-            return c['id']
+        args = {
+            'zoneid': self.get_zone(key='id')
+        }
+        clusters = self.query_api('listClusters', **args)
+        if clusters:
+            for c in clusters['cluster']:
+                if cluster_name in [c['name'], c['id']]:
+                    return c['id']
       
-      self.fail_json(msg="Cluster '%s' not found" % cluster_name)
+        self.fail_json(msg="Cluster '%s' not found" % cluster_name)
 
     def get_pod_id(self):
-      pod_name = self.module.params.get('pod')
-      if not pod_name:
-        return None
+        pod_name = self.module.params.get('pod')
+        if not pod_name:
+            return None
 
-      args = {
-        'zoneid': self.get_zone(key='id')
-      }
-      pods = self.query_api('listPods', **args)
-      if pods:
-        for p in pods['pod']:
-          if pod_name in [p['name'], p['id']]:
-            return p['id']
+        args = {
+            'zoneid': self.get_zone(key='id')
+        }
+        pods = self.query_api('listPods', **args)
+        if pods:
+            for p in pods['pod']:
+                if pod_name in [p['name'], p['id']]:
+                    return p['id']
       
-      self.fail_json(msg="Pod '%s' not found" % pod_name) 
+        self.fail_json(msg="Pod '%s' not found" % pod_name)
 
     def get_template_or_iso(self, key=None):
         template = self.module.params.get('template')


### PR DESCRIPTION
Addresses; https://github.com/ngine-io/ansible-collection-cloudstack/issues/100

#### How was it tested:
Created a VM passing pod and cluster name / id and it successfully created the VM in the specified cluster / pod
```
---
- name: provision our VMs
  hosts: localhost
  become: yes
  tasks:
  - name: Test deploy VM in a host 
    ngine_io.cloudstack.cs_instance:    
      name: web-vm-3
      template: CentOS 5.6 (64-bit) no GUI (Simulator)
      hypervisor: Simulator
      service_offering: Small Instance
      zone: 2ee3462f-1c0c-4f9d-858e-c5f649fc5244
      host: SimulatedAgent.b1b58604-28c6-4729-9774-3f11bed0baa8
      cluster: C0
      pod: POD0
      networks: net1
```

Translated to the following request on ACS end:

```
cmd: org.apache.cloudstack.api.command.admin.vm.DeployVMCmdByAdmin, cmdInfo: {"expires":"2022-06-10T12:50:32+0000","apiKey":"XTMBzlbFgs5VLu_ZpCZVscP8bnMlnaGzvF9_u8gh-APFH5KxOpuftSsHkuqYiuhZlEYyFSh2eKx3M9YTcpnZfw","signature":"aY+fN9vOtBmuaSJMExXJ00NYIeQ\u003d","hostid":"4bc9774d-53ad-4e8c-b07f-c5e27b173360","httpmethod":"GET","clusterid":"fd81c970-0a36-4ab5-b664-39e07f3df1a4","templateid":"d0bbf662-e8a8-11ec-98d4-50eb7122da94","signatureVersion":"3","ctxAccountId":"2","uuid":"58c8fe78-b6f3-4bb5-b1f6-42c262b5e5e4","cmdEventType":"VM.CREATE","startvm":"True","networkids":"2f17c175-504f-4c9c-b066-6dc11caafd58","serviceofferingid":"c08a77c4-5ef5-4de2-9c85-3ebf046dfbf4","response":"json","ctxUserId":"2","displayname":"web-vm-3","name":"web-vm-3","zoneid":"2ee3462f-1c0c-4f9d-858e-c5f649fc5244","ctxStartEventId":"77","id":"6","ctxDetails":"{\"interface com.cloud.dc.Pod\":\"81f1bb5d-6e0d-48df-9145-d07bf42823d7\",\"interface com.cloud.network.Network\":\"2f17c175-504f-4c9c-b066-6dc11caafd58\",\"interface com.cloud.offering.ServiceOffering\":\"c08a77c4-5ef5-4de2-9c85-3ebf046dfbf4\",\"interface com.cloud.host.Host\":\"4bc9774d-53ad-4e8c-b07f-c5e27b173360\",\"interface com.cloud.dc.DataCenter\":\"2ee3462f-1c0c-4f9d-858e-c5f649fc5244\",\"interface com.cloud.org.Cluster\":\"fd81c970-0a36-4ab5-b664-39e07f3df1a4\",\"interface com.cloud.template.VirtualMachineTemplate\":\"d0bbf662-e8a8-11ec-98d4-50eb7122da94\",\"interface com.cloud.vm.VirtualMachine\":\"58c8fe78-b6f3-4bb5-b1f6-42c262b5e5e4\"}","podid":"81f1bb5d-6e0d-48df-9145-d07bf42823d7"}, cmdVersion: 0, status: IN_PROGRESS, processStatus: 0, resultCode: 0, result: null, initMsid: 2484687444629, completeMsid: null, lastUpdated: null, lastPolled: null, created: null, removed: null}

```