### PR TITLE
Fix port forward rule creation for primary IP of default NIC

### DIFF
--- a/plugins/module_utils/cloudstack.py
+++ b/plugins/module_utils/cloudstack.py
@@ -402,7 +402,7 @@ class AnsibleCloudStack:
         vm_guest_ip = self.module.params.get('vm_guest_ip')
         default_nic = self.get_vm_default_nic()
 
-        if not vm_guest_ip:
+        if not vm_guest_ip or vm_guest_ip == default_nic['ipaddress']:
             return default_nic['ipaddress']
 
         for secondary_ip in default_nic['secondaryip']:

--- a/plugins/modules/cs_portforward.py
+++ b/plugins/modules/cs_portforward.py
@@ -69,7 +69,7 @@ options:
     type: bool
   vm_guest_ip:
     description:
-      - VM guest NIC secondary IP address for the port forwarding rule.
+      - VM guest NIC IP address for the port forwarding rule.
     type: str
   network:
     description:


### PR DESCRIPTION
Attempts to fix: https://github.com/ngine-io/ansible-collection-cloudstack/issues/108

Tests:
Created an Isolated & VPC network with multiple NICS
- Tried creating port-forward rule for primary IP on default NIC - PASS
- Tried creating port-forward rule for secondary IP on default NIC - PASS

