### PR TITLE
service_capabilities is a dict

### DIFF
--- a/plugins/modules/cs_network_offering.py
+++ b/plugins/modules/cs_network_offering.py
@@ -94,7 +94,7 @@ options:
     description:
       - Desired service capabilities as part of network offering.
     type: list
-    elements: str
+    elements: dict
     aliases: [ service_capability ]
   service_offering:
     description:

--- a/plugins/modules/cs_network_offering.py
+++ b/plugins/modules/cs_network_offering.py
@@ -455,7 +455,7 @@ def main():
         keepalive_enabled=dict(type='bool'),
         max_connections=dict(type='int'),
         network_rate=dict(type='int'),
-        service_capabilities=dict(type='list', elements='str', aliases=['service_capability']),
+        service_capabilities=dict(type='list', elements='dict', aliases=['service_capability']),
         service_offering=dict(),
         service_providers=dict(type='list', elements='dict', aliases=['service_provider']),
         specify_ip_ranges=dict(type='bool'),


### PR DESCRIPTION
Network Offering -> service_capability is a dict, not a string. Conversion causes an error to be returned from the API.