### PR TITLE
Adds additional supported_services in network offering

### DIFF
--- a/plugins/modules/cs_network_offering.py
+++ b/plugins/modules/cs_network_offering.py
@@ -45,7 +45,7 @@ options:
       - A list of one or more items from the choice list.
     type: list
     elements: str
-    choices: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    choices: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb, NetworkACL, SecurityGroup, Connectivity, BaremetalPxeService ]
     aliases: [ supported_service ]
   traffic_type:
     description:
@@ -155,7 +155,7 @@ EXAMPLES = '''
     display_text: network offering description
     state: enabled
     guest_ip_type: Isolated
-    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb, NetworkACL, SecurityGroup, Connectivity, BaremetalPxeService ]
     service_providers:
       - { service: 'dns', provider: 'virtualrouter' }
       - { service: 'dhcp', provider: 'virtualrouter' }
@@ -445,6 +445,10 @@ def main():
             'StaticNat',
             'Vpn',
             'Lb',
+            'NetworkACL',
+            'SecurityGroup',
+            'Connectivity',
+            'BaremetalPxeService',
         ]),
         traffic_type=dict(default='Guest'),
         availability=dict(),

--- a/plugins/modules/cs_network_offering.py
+++ b/plugins/modules/cs_network_offering.py
@@ -155,7 +155,20 @@ EXAMPLES = '''
     display_text: network offering description
     state: enabled
     guest_ip_type: Isolated
-    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb, NetworkACL, SecurityGroup, Connectivity, BaremetalPxeService ]
+    supported_services:
+      - Dns
+      - PortForwarding
+      - Dhcp
+      - SourceNat
+      - UserData
+      - Firewall
+      - StaticNat
+      - Vpn
+      - Lb
+      - NetworkACL
+      - SecurityGroup
+      - Connectivity
+      - BaremetalPxeService
     service_providers:
       - { service: 'dns', provider: 'virtualrouter' }
       - { service: 'dhcp', provider: 'virtualrouter' }


### PR DESCRIPTION
Adds additional supported_services to the allowed list in cs_network_offering,
tested NetworkACL service in cs 4.17


edit:  attaching source link & screenshots

- doc source link  
https://docs.cloudstack.apache.org/en/latest/adminguide/networking.html
11 of them are listed here

![image](https://github.com/ngine-io/ansible-collection-cloudstack/assets/65233979/cd76b3a2-6db0-4e9c-b068-31ffaf518fa5)


- in cs ui there are 13 services
![Screenshot from 2023-07-28 13-43-20](https://github.com/ngine-io/ansible-collection-cloudstack/assets/65233979/93fd5f9e-3f2a-4edd-8c45-b47220589c04)
![Screenshot from 2023-07-28 13-44-10](https://github.com/ngine-io/ansible-collection-cloudstack/assets/65233979/132ac4ea-6ea4-48fb-9248-1018a3a5f2b9)
![Screenshot from 2023-07-28 13-44-16](https://github.com/ngine-io/ansible-collection-cloudstack/assets/65233979/82f106cd-1743-45cb-a8d6-5a4b42f64fbb)



