### PR TITLE
Add possibility to skip certificate validation

### DIFF
--- a/plugins/doc_fragments/cloudstack.py
+++ b/plugins/doc_fragments/cloudstack.py
@@ -47,6 +47,7 @@ options:
     description:
       - Verify CA authority cert file.
       - If not given, the C(CLOUDSTACK_VERIFY) env variable is considered.
+      - If is null, we skip the verification of the certificate.
     type: str
 requirements:
   - python >= 2.6

--- a/plugins/module_utils/cloudstack.py
+++ b/plugins/module_utils/cloudstack.py
@@ -122,6 +122,10 @@ class AnsibleCloudStack:
             'method': self.module.params.get('api_http_method'),
             'verify': self.module.params.get('api_verify_ssl_cert'),
         }
+        
+        if not api_config['verify']:
+            api_config["dangerous_no_tls_verify"] = True
+
         self.result.update({
             'api_url': api_config['endpoint'],
             'api_key': api_config['key'],


### PR DESCRIPTION
Hi team,

i simply add the possibility to skip ssl verification if verify is null. 
In `cs` library we need to se `dangerous_no_tls_verify` to true for skip verification.

I simply add this on this pull request