### PR TITLE
Add template tags when registering a template

### DIFF
--- a/plugins/modules/template.py
+++ b/plugins/modules/template.py
@@ -516,6 +516,7 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
         if not self.module.check_mode:
             self.query_api("registerTemplate", **args)
             template = self.get_template()
+            template = self.ensure_tags(resource=template, resource_type="Template")
         return template
 
     def update_template(self, template):


### PR DESCRIPTION
This PR fixes a small bug where template tags were not added to a template when first registering it.