### PR TITLE
portforward: Fix rule creation for primary IP of default NIC

### DIFF
--- a/changelogs/fragments/110-fix-portforward.yml
+++ b/changelogs/fragments/110-fix-portforward.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- portforward - Fixed rule creation for primary IP of default NIC (https://github.com/ngine-io/ansible-collection-cloudstack/issues/108)

--- a/plugins/module_utils/cloudstack.py
+++ b/plugins/module_utils/cloudstack.py
@@ -400,7 +400,7 @@ class AnsibleCloudStack:
         vm_guest_ip = self.module.params.get("vm_guest_ip")
         default_nic = self.get_vm_default_nic()
 
-        if not vm_guest_ip:
+        if not vm_guest_ip or (default_nic is not None and vm_guest_ip == default_nic["ipaddress"]):
             return default_nic["ipaddress"] if default_nic is not None else ""
 
         for secondary_ip in default_nic.get("secondaryip", []) if default_nic is not None else []:

--- a/plugins/modules/portforward.py
+++ b/plugins/modules/portforward.py
@@ -69,7 +69,7 @@ options:
     type: bool
   vm_guest_ip:
     description:
-      - VM guest NIC secondary IP address for the port forwarding rule.
+      - VM guest NIC IP address for the port forwarding rule.
     type: str
   network:
     description:


### PR DESCRIPTION
closes #110 
closes #108 