### PR TITLE
add modules for internal load balancers

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -20,8 +20,11 @@ action_groups:
     - instance_password_reset
     - instance
     - instance_snapshot
+    - internal_lb_vm
     - ip_address
     - iso
+    - lb_internal_member
+    - lb_internal
     - lb_rule_member
     - lb_rule
     - metadata_facts

--- a/plugins/modules/internal_lb_vm.py
+++ b/plugins/modules/internal_lb_vm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
+# Copyright (c) 2026, Mitch Drage <mitch@lsnetworks.com.au>
 # Copyright (c) 2026, René Moser <mail@renemoser.net>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -19,7 +20,7 @@ description:
     - The instance itself can not be created or destroyed through this API family. CloudStack
       deploys it automatically once the first member is assigned to an internal load balancer,
       see M(ngine_io.cloudstack.lb_internal_member).
-author: René Moser (@resmo)
+author: Mitch Drage (@MitchDrage)
 options:
   name:
     description:

--- a/plugins/modules/internal_lb_vm.py
+++ b/plugins/modules/internal_lb_vm.py
@@ -1,0 +1,336 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+---
+module: internal_lb_vm
+short_description: Manages internal load balancer instances on Apache CloudStack based clouds.
+description:
+    - Start and stop the C(InternalLbVm) system instance which serves the internal load
+      balancers of a VPC tier.
+    - The instance itself can not be created or destroyed through this API family. CloudStack
+      deploys it automatically once the first member is assigned to an internal load balancer,
+      see M(ngine_io.cloudstack.lb_internal_member).
+author: René Moser (@resmo)
+options:
+  name:
+    description:
+      - Name of the internal load balancer instance, e.g. C(b-1234-VM).
+      - Mutually sufficient with I(network) and I(vpc), at least one of them is required.
+    type: str
+  network:
+    description:
+      - Name of the VPC tier the internal load balancer instance serves.
+    type: str
+  vpc:
+    description:
+      - Name of the VPC the internal load balancer instance belongs to.
+      - Also scopes the I(network) lookup.
+    type: str
+  zone:
+    description:
+      - Name of the zone the internal load balancer instance is in.
+    type: str
+    required: true
+  domain:
+    description:
+      - Domain the internal load balancer instance is related to.
+    type: str
+  account:
+    description:
+      - Account the internal load balancer instance is related to.
+    type: str
+  project:
+    description:
+      - Name of the project the internal load balancer instance is related to.
+    type: str
+  state:
+    description:
+      - State of the internal load balancer instance.
+    type: str
+    default: started
+    choices: [ started, stopped ]
+  force:
+    description:
+      - Whether to force stop the instance.
+      - Only considered on I(state=stopped).
+    type: bool
+    default: false
+  poll_async:
+    description:
+      - Poll async jobs until job has finished.
+    type: bool
+    default: true
+notes:
+  - This module uses admin only APIs. A regular user account gets an empty result from
+    C(listInternalLoadBalancerVMs) and the module will not find the instance.
+  - There is no API to create or destroy an internal load balancer instance, so this module
+    provides no I(state=present) or I(state=absent).
+  - When more than one instance matches, the module fails and asks for a more specific
+    selection. Pass I(name) to disambiguate.
+extends_documentation_fragment:
+- ngine_io.cloudstack.cloudstack
+"""
+
+EXAMPLES = """
+- name: Ensure the internal load balancer instance of a tier is running
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    state: started
+
+- name: Ensure a specific internal load balancer instance is stopped
+  ngine_io.cloudstack.internal_lb_vm:
+    name: b-1234-VM
+    zone: zone01
+    state: stopped
+
+- name: Force stop the internal load balancer instance of a tier
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    state: stopped
+    force: true
+"""
+
+RETURN = """
+---
+id:
+  description: UUID of the internal load balancer instance.
+  returned: success
+  type: str
+  sample: 04589590-ac63-4ffc-93f5-b698b8ac38b6
+name:
+  description: Name of the internal load balancer instance.
+  returned: success
+  type: str
+  sample: b-1234-VM
+state:
+  description: State of the internal load balancer instance.
+  returned: success
+  type: str
+  sample: Running
+public_ip:
+  description: Public IP of the internal load balancer instance.
+  returned: when available
+  type: str
+  sample: 10.10.1.247
+guest_ip_address:
+  description: Guest IP of the internal load balancer instance.
+  returned: when available
+  type: str
+  sample: 10.10.1.247
+network_id:
+  description: UUID of the guest network the internal load balancer instance serves.
+  returned: when available
+  type: str
+  sample: e83f0010-4e08-493f-acc8-f5205d83b30d
+vpc_id:
+  description: UUID of the VPC the internal load balancer instance belongs to.
+  returned: when available
+  type: str
+  sample: 87b1e0ce-4e01-11e4-bb66-0050569e64b8
+service_offering:
+  description: Name of the service offering of the internal load balancer instance.
+  returned: when available
+  type: str
+  sample: System Offering For Software Router
+template_version:
+  description: Version of the system VM template.
+  returned: when available
+  type: str
+  sample: CloudStack Release 4.20
+requires_upgrade:
+  description: Whether the internal load balancer instance requires an upgrade.
+  returned: when available
+  type: bool
+  sample: false
+host:
+  description: Hostname of the host the internal load balancer instance is running on.
+  returned: when available
+  type: str
+  sample: host01
+created:
+  description: Date of the internal load balancer instance was created.
+  returned: when available
+  type: str
+  sample: 2026-02-08T11:26:24+0100
+zone:
+  description: Name of zone the internal load balancer instance is in.
+  returned: success
+  type: str
+  sample: zone01
+account:
+  description: Account the internal load balancer instance is related to.
+  returned: when available
+  type: str
+  sample: example-account
+domain:
+  description: Domain the internal load balancer instance is related to.
+  returned: when available
+  type: str
+  sample: ROOT
+project:
+  description: Name of project the internal load balancer instance is related to.
+  returned: when available
+  type: str
+  sample: Production
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
+
+
+class AnsibleCloudStackInternalLbVm(AnsibleCloudStack):
+    """AnsibleCloudStackInternalLbVm"""
+
+    def __init__(self, module):
+        super(AnsibleCloudStackInternalLbVm, self).__init__(module)
+        self.internal_lb_vm = None
+        self.returns = {
+            "guestipaddress": "guest_ip_address",
+            "guestnetworkid": "network_id",
+            "hostname": "host",
+            "publicip": "public_ip",
+            "requiresupgrade": "requires_upgrade",
+            "serviceofferingname": "service_offering",
+            "version": "template_version",
+            "vpcid": "vpc_id",
+        }
+
+    def get_internal_lb_vm(self):
+        if self.internal_lb_vm:
+            return self.internal_lb_vm
+
+        args = {
+            "account": self.get_account(key="name"),
+            "domainid": self.get_domain(key="id"),
+            "projectid": self.get_project(key="id"),
+            "zoneid": self.get_zone(key="id"),
+            "listall": True,
+            "fetch_list": True,
+        }
+
+        if self.module.params.get("vpc"):
+            args["vpcid"] = self.get_vpc(key="id")
+
+        if self.module.params.get("network"):
+            args["networkid"] = self.get_network(key="id")
+
+        internal_lb_vms = self.query_api("listInternalLoadBalancerVMs", **args) or []
+
+        name = self.module.params.get("name")
+        if name:
+            internal_lb_vms = [v for v in internal_lb_vms if name.lower() in [v["name"].lower(), v["id"]]]
+
+        if len(internal_lb_vms) > 1:
+            self.fail_json(
+                msg="More than one internal load balancer instance found: %s. "
+                "Pass name to select one of them." % ", ".join(sorted(v["name"] for v in internal_lb_vms))
+            )
+
+        if internal_lb_vms:
+            self.internal_lb_vm = internal_lb_vms[0]
+
+        return self.internal_lb_vm
+
+    def _get_or_fail(self):
+        internal_lb_vm = self.get_internal_lb_vm()
+        if not internal_lb_vm:
+            self.fail_json(
+                msg="Internal load balancer instance not found. It is deployed by CloudStack "
+                "once the first member is assigned to an internal load balancer. Note that "
+                "listInternalLoadBalancerVMs is an admin only API."
+            )
+        return internal_lb_vm
+
+    def start_internal_lb_vm(self):
+        internal_lb_vm = self._get_or_fail()
+
+        if internal_lb_vm["state"].lower() != "running":
+            self.result["changed"] = True
+            self.result["diff"]["before"]["state"] = internal_lb_vm["state"]
+            self.result["diff"]["after"]["state"] = "Running"
+
+            if not self.module.check_mode:
+                res = self.query_api("startInternalLoadBalancerVM", id=internal_lb_vm["id"])
+                if self.module.params.get("poll_async"):
+                    self.poll_job(res)
+                    self.internal_lb_vm = None
+                    internal_lb_vm = self.get_internal_lb_vm()
+
+        return internal_lb_vm
+
+    def stop_internal_lb_vm(self):
+        internal_lb_vm = self._get_or_fail()
+
+        if internal_lb_vm["state"].lower() != "stopped":
+            self.result["changed"] = True
+            self.result["diff"]["before"]["state"] = internal_lb_vm["state"]
+            self.result["diff"]["after"]["state"] = "Stopped"
+
+            if not self.module.check_mode:
+                args = {
+                    "id": internal_lb_vm["id"],
+                    "forced": self.module.params.get("force"),
+                }
+                res = self.query_api("stopInternalLoadBalancerVM", **args)
+                if self.module.params.get("poll_async"):
+                    self.poll_job(res)
+                    self.internal_lb_vm = None
+                    internal_lb_vm = self.get_internal_lb_vm()
+
+        return internal_lb_vm
+
+
+def main():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(
+        dict(
+            account=dict(type="str"),
+            domain=dict(type="str"),
+            force=dict(type="bool", default=False),
+            name=dict(type="str"),
+            network=dict(type="str"),
+            poll_async=dict(type="bool", default=True),
+            project=dict(type="str"),
+            state=dict(type="str", choices=["started", "stopped"], default="started"),
+            vpc=dict(type="str"),
+            zone=dict(type="str", required=True),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=cs_required_together(),
+        required_one_of=[
+            ("name", "network", "vpc"),
+        ],
+        supports_check_mode=True,
+    )
+
+    acs_internal_lb_vm = AnsibleCloudStackInternalLbVm(module)
+
+    state = module.params.get("state")
+    if state == "stopped":
+        internal_lb_vm = acs_internal_lb_vm.stop_internal_lb_vm()
+    else:
+        internal_lb_vm = acs_internal_lb_vm.start_internal_lb_vm()
+
+    result = acs_internal_lb_vm.get_result(internal_lb_vm)
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/lb_internal.py
+++ b/plugins/modules/lb_internal.py
@@ -74,6 +74,14 @@ options:
       - Whether the internal load balancer is displayed to the regular user.
       - Requires an admin account to be idempotent, see the notes below.
     type: bool
+  force:
+    description:
+      - Whether to delete and recreate the internal load balancer when an option which can not
+        be updated differs from the existing one.
+      - Without it, such a difference fails the task instead.
+      - Only considered on I(state=present). See the notes below for the consequences.
+    type: bool
+    default: false
   vpc:
     description:
       - Name of the VPC the I(network) belongs to.
@@ -108,10 +116,17 @@ options:
     default: true
 notes:
   - The CloudStack API only allows I(for_display) to be updated on an existing internal
-    load balancer. When any other option differs from an existing load balancer, this
-    module fails and names the differing options instead of recreating it, so a live load
-    balancer is never torn down by an unrelated playbook run. Use I(state=absent) followed
-    by I(state=present) to apply such a change.
+    load balancer. When any other option differs, this module fails and names the differing
+    options, so a live load balancer is never torn down by an unrelated playbook run. Set
+    I(force=true) to delete and recreate it instead, or use I(state=absent) followed by
+    I(state=present).
+  - I(force=true) only acts when an option actually differs, so it stays idempotent and can
+    safely be driven by a playbook variable.
+  - Recreating drops every member assigned to the load balancer. Re-apply them with
+    M(ngine_io.cloudstack.lb_internal_member) afterwards.
+  - Recreating allocates a new source IP address unless I(source_ip) is given. Anything
+    pointing at the previous address stops working, so pin I(source_ip) when using
+    I(force=true).
   - The API returns C(fordisplay) to admin accounts only. When running as a regular user,
     this module can not detect drift on I(for_display) and will emit a warning instead of
     updating it. I(for_display) is always applied on creation.
@@ -143,6 +158,17 @@ EXAMPLES = """
     source_port: 80
     instance_port: 8080
     source_ip: 10.10.1.100
+
+- name: Ensure an internal load balancer, recreating it if an immutable option changed
+  ngine_io.cloudstack.lb_internal:
+    name: web-ilb
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    source_ip: 10.10.1.100
+    source_port: 8080
+    instance_port: 8080
+    force: true
 
 - name: Ensure an internal load balancer is absent
   ngine_io.cloudstack.lb_internal:
@@ -331,7 +357,7 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
         return lb_rules[0] if lb_rules else {}
 
     def _get_immutable_diff(self, lb_internal):
-        """Return a list of human readable diffs of options which can not be updated."""
+        """Return a list of (option, current, wanted) for options which can not be updated."""
         lb_rule = self._get_lb_rule(lb_internal)
 
         # (module option, wanted value, current value)
@@ -354,10 +380,12 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
                 continue
 
             if isinstance(wanted, int):
-                if current is None or int(current) != wanted:
-                    diff.append("%s (current: %s, wanted: %s)" % (option, current, wanted))
-            elif str(current).lower() != str(wanted).lower():
-                diff.append("%s (current: %s, wanted: %s)" % (option, current, wanted))
+                differs = current is None or int(current) != wanted
+            else:
+                differs = str(current).lower() != str(wanted).lower()
+
+            if differs:
+                diff.append((option, current, wanted))
 
         return diff
 
@@ -393,37 +421,67 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
 
         return lb_internal
 
+    def _create_lb_internal(self):
+        args = self._get_common_args()
+        args.update(
+            {
+                "algorithm": self.module.params.get("algorithm"),
+                "description": self.module.params.get("description"),
+                "fordisplay": self.module.params.get("for_display"),
+                "instanceport": self.module.params.get("instance_port"),
+                "scheme": LB_SCHEME,
+                "sourceipaddress": self.module.params.get("source_ip"),
+                "sourceipaddressnetworkid": self.get_source_ip_network(key="id"),
+                "sourceport": self.module.params.get("source_port"),
+            }
+        )
+
+        lb_internal = None
+        if not self.module.check_mode:
+            res = self.query_api("createLoadBalancer", **args)
+            if self.module.params.get("poll_async"):
+                lb_internal = self.poll_job(res, "loadbalancer")
+        return lb_internal
+
+    def _recreate_lb_internal(self, lb_internal, diff):
+        """Delete and recreate, the only way to change an option the API treats as immutable."""
+        self.result["changed"] = True
+        for option, current, wanted in diff:
+            self.result["diff"]["before"][option] = current
+            self.result["diff"]["after"][option] = wanted
+
+        if self.module.check_mode:
+            return lb_internal
+
+        res = self.query_api("deleteLoadBalancer", id=lb_internal["id"])
+        if self.module.params.get("poll_async"):
+            self.poll_job(res)
+
+        self.lb_internal = None
+        return self._create_lb_internal()
+
     def present_lb_internal(self):
         lb_internal = self.get_lb_internal()
 
         if lb_internal:
             diff = self._get_immutable_diff(lb_internal)
-            if diff:
+            if not diff:
+                lb_internal = self._update_for_display(lb_internal)
+            elif self.module.params.get("force"):
+                lb_internal = self._recreate_lb_internal(lb_internal, diff)
+            else:
                 self.fail_json(
                     msg="Internal load balancer '%s' exists but the following options can not be "
-                    "changed: %s. Use state=absent followed by state=present to recreate it." % (self.module.params.get("name"), ", ".join(diff))
+                    "changed: %s. Use force=true to delete and recreate it, or state=absent "
+                    "followed by state=present."
+                    % (
+                        self.module.params.get("name"),
+                        ", ".join("%s (current: %s, wanted: %s)" % d for d in diff),
+                    )
                 )
-            lb_internal = self._update_for_display(lb_internal)
         else:
             self.result["changed"] = True
-            args = self._get_common_args()
-            args.update(
-                {
-                    "algorithm": self.module.params.get("algorithm"),
-                    "description": self.module.params.get("description"),
-                    "fordisplay": self.module.params.get("for_display"),
-                    "instanceport": self.module.params.get("instance_port"),
-                    "scheme": LB_SCHEME,
-                    "sourceipaddress": self.module.params.get("source_ip"),
-                    "sourceipaddressnetworkid": self.get_source_ip_network(key="id"),
-                    "sourceport": self.module.params.get("source_port"),
-                }
-            )
-
-            if not self.module.check_mode:
-                res = self.query_api("createLoadBalancer", **args)
-                if self.module.params.get("poll_async"):
-                    lb_internal = self.poll_job(res, "loadbalancer")
+            lb_internal = self._create_lb_internal()
 
         self.lb_internal = lb_internal
         return lb_internal
@@ -459,6 +517,7 @@ def main():
             description=dict(type="str"),
             domain=dict(type="str"),
             for_display=dict(type="bool"),
+            force=dict(type="bool", default=False),
             instance_port=dict(type="int"),
             name=dict(type="str", required=True),
             network=dict(type="str", required=True),

--- a/plugins/modules/lb_internal.py
+++ b/plugins/modules/lb_internal.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
+# Copyright (c) 2026, Mitch Drage <mitch@lsnetworks.com.au>
 # Copyright (c) 2026, René Moser <mail@renemoser.net>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -19,7 +20,7 @@ description:
       which manages public load balancer rules only and can not see or manage internal ones.
     - Existing internal load balancers are matched by name within the network scope.
     - Only I(for_display) can be changed after creation. See the notes below.
-author: René Moser (@resmo)
+author: Mitch Drage (@MitchDrage)
 options:
   name:
     description:

--- a/plugins/modules/lb_internal.py
+++ b/plugins/modules/lb_internal.py
@@ -401,8 +401,7 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
             if diff:
                 self.fail_json(
                     msg="Internal load balancer '%s' exists but the following options can not be "
-                    "changed: %s. Use state=absent followed by state=present to recreate it."
-                    % (self.module.params.get("name"), ", ".join(diff))
+                    "changed: %s. Use state=absent followed by state=present to recreate it." % (self.module.params.get("name"), ", ".join(diff))
                 )
             lb_internal = self._update_for_display(lb_internal)
         else:

--- a/plugins/modules/lb_internal.py
+++ b/plugins/modules/lb_internal.py
@@ -49,14 +49,16 @@ options:
   algorithm:
     description:
       - Load balancing algorithm.
+      - Defaults to C(source) when the load balancer is created.
+      - When not given, the algorithm of an existing load balancer is left as it is.
       - Can not be changed after creation.
     type: str
-    default: source
     choices: [ source, roundrobin, leastconn ]
   source_ip:
     description:
       - Source IP address of the internal load balancer.
       - Automatically allocated from I(source_ip_network) when not given.
+      - On I(force=true), the address of the existing load balancer is kept when not given.
       - Can not be changed after creation.
     type: str
   source_ip_network:
@@ -125,9 +127,8 @@ notes:
     safely be driven by a playbook variable.
   - Recreating drops every member assigned to the load balancer. Re-apply them with
     M(ngine_io.cloudstack.lb_internal_member) afterwards.
-  - Recreating allocates a new source IP address unless I(source_ip) is given. Anything
-    pointing at the previous address stops working, so pin I(source_ip) when using
-    I(force=true).
+  - Recreating keeps the source IP address of the existing load balancer, so the address
+    stays stable across a recreate. Give I(source_ip) to move it to a different address.
   - The API returns C(fordisplay) to admin accounts only. When running as a regular user,
     this module can not detect drift on I(for_display) and will emit a warning instead of
     updating it. I(for_display) is always applied on creation.
@@ -166,7 +167,6 @@ EXAMPLES = """
     vpc: my-vpc
     network: web-tier
     zone: zone01
-    source_ip: 10.10.1.100
     source_port: 8080
     instance_port: 8080
     force: true
@@ -266,6 +266,9 @@ from ..module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_re
 # The API only accepts this scheme, see CreateApplicationLoadBalancerCmd. It is deliberately
 # not exposed as an option, as that would imply a Public option the API rejects.
 LB_SCHEME = "Internal"
+
+# Applied on creation only, see _create_lb_internal().
+LB_DEFAULT_ALGORITHM = "source"
 
 
 class AnsibleCloudStackLbInternal(AnsibleCloudStack):
@@ -422,16 +425,19 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
 
         return lb_internal
 
-    def _create_lb_internal(self):
+    def _create_lb_internal(self, source_ip=None):
         args = self._get_common_args()
         args.update(
             {
-                "algorithm": self.module.params.get("algorithm"),
+                # The default is applied here rather than in the argument spec: a spec level
+                # default is indistinguishable from a value the user asked for, and would make
+                # an omitted algorithm look like drift on an existing load balancer.
+                "algorithm": self.module.params.get("algorithm") or LB_DEFAULT_ALGORITHM,
                 "description": self.module.params.get("description"),
                 "fordisplay": self.module.params.get("for_display"),
                 "instanceport": self.module.params.get("instance_port"),
                 "scheme": LB_SCHEME,
-                "sourceipaddress": self.module.params.get("source_ip"),
+                "sourceipaddress": self.module.params.get("source_ip") or source_ip,
                 "sourceipaddressnetworkid": self.get_source_ip_network(key="id"),
                 "sourceport": self.module.params.get("source_port"),
             }
@@ -454,12 +460,16 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
         if self.module.check_mode:
             return lb_internal
 
+        # Keep the address the load balancer already has, so consumers pointing at the VIP
+        # keep working across the recreate. An explicit source_ip still wins.
+        source_ip = lb_internal.get("sourceipaddress")
+
         res = self.query_api("deleteLoadBalancer", id=lb_internal["id"])
         if self.module.params.get("poll_async"):
             self.poll_job(res)
 
         self.lb_internal = None
-        return self._create_lb_internal()
+        return self._create_lb_internal(source_ip=source_ip)
 
     def present_lb_internal(self):
         lb_internal = self.get_lb_internal()
@@ -514,7 +524,7 @@ def main():
     argument_spec.update(
         dict(
             account=dict(type="str"),
-            algorithm=dict(type="str", choices=["source", "roundrobin", "leastconn"], default="source"),
+            algorithm=dict(type="str", choices=["source", "roundrobin", "leastconn"]),
             description=dict(type="str"),
             domain=dict(type="str"),
             for_display=dict(type="bool"),

--- a/plugins/modules/lb_internal.py
+++ b/plugins/modules/lb_internal.py
@@ -1,0 +1,499 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+---
+module: lb_internal
+short_description: Manages internal load balancers on Apache CloudStack based clouds.
+description:
+    - Create and remove internal (application) load balancers on a VPC tier.
+    - Internal load balancers use a different API family than M(ngine_io.cloudstack.lb_rule),
+      which manages public load balancer rules only and can not see or manage internal ones.
+    - Existing internal load balancers are matched by name within the network scope.
+    - Only I(for_display) can be changed after creation. See the notes below.
+author: René Moser (@resmo)
+options:
+  name:
+    description:
+      - Name of the internal load balancer.
+    type: str
+    required: true
+  network:
+    description:
+      - Name of the VPC tier the internal load balancer balances traffic to.
+      - The network offering of this tier must support the LB service with the
+        C(InternalLbVm) provider.
+    type: str
+    required: true
+  source_port:
+    description:
+      - Source port the internal load balancer listens on.
+      - Required on I(state=present).
+      - Can not be changed after creation.
+    type: int
+  instance_port:
+    description:
+      - Port on the balanced instances traffic is forwarded to.
+      - Required on I(state=present).
+      - Can not be changed after creation.
+    type: int
+  algorithm:
+    description:
+      - Load balancing algorithm.
+      - Can not be changed after creation.
+    type: str
+    default: source
+    choices: [ source, roundrobin, leastconn ]
+  source_ip:
+    description:
+      - Source IP address of the internal load balancer.
+      - Automatically allocated from I(source_ip_network) when not given.
+      - Can not be changed after creation.
+    type: str
+  source_ip_network:
+    description:
+      - Name of the network the source IP address is taken from.
+      - Defaults to I(network) when not given.
+      - Can not be changed after creation.
+    type: str
+  description:
+    description:
+      - Description of the internal load balancer.
+      - Only used on creation, see the notes below.
+    type: str
+  for_display:
+    description:
+      - Whether the internal load balancer is displayed to the regular user.
+      - Requires an admin account to be idempotent, see the notes below.
+    type: bool
+  vpc:
+    description:
+      - Name of the VPC the I(network) belongs to.
+    type: str
+  zone:
+    description:
+      - Name of the zone the internal load balancer belongs to.
+    type: str
+    required: true
+  domain:
+    description:
+      - Domain the internal load balancer is related to.
+    type: str
+  account:
+    description:
+      - Account the internal load balancer is related to.
+    type: str
+  project:
+    description:
+      - Name of the project the internal load balancer is related to.
+    type: str
+  state:
+    description:
+      - State of the internal load balancer.
+    type: str
+    default: present
+    choices: [ present, absent ]
+  poll_async:
+    description:
+      - Poll async jobs until job has finished.
+    type: bool
+    default: true
+notes:
+  - The CloudStack API only allows I(for_display) to be updated on an existing internal
+    load balancer. When any other option differs from an existing load balancer, this
+    module fails and names the differing options instead of recreating it, so a live load
+    balancer is never torn down by an unrelated playbook run. Use I(state=absent) followed
+    by I(state=present) to apply such a change.
+  - The API returns C(fordisplay) to admin accounts only. When running as a regular user,
+    this module can not detect drift on I(for_display) and will emit a warning instead of
+    updating it. I(for_display) is always applied on creation.
+  - The API does not return I(description) at all, so it can neither be verified nor changed
+    after creation.
+  - Members are managed separately and are not in the scope of this module. They can be
+    assigned using the C(assignToLoadBalancerRule) API.
+extends_documentation_fragment:
+- ngine_io.cloudstack.cloudstack
+"""
+
+EXAMPLES = """
+- name: Ensure an internal load balancer is present
+  ngine_io.cloudstack.lb_internal:
+    name: web-ilb
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+
+- name: Ensure an internal load balancer with a fixed source IP
+  ngine_io.cloudstack.lb_internal:
+    name: web-ilb
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    source_port: 80
+    instance_port: 8080
+    source_ip: 10.10.1.100
+
+- name: Ensure an internal load balancer is absent
+  ngine_io.cloudstack.lb_internal:
+    name: web-ilb
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    state: absent
+"""
+
+RETURN = """
+---
+id:
+  description: UUID of the internal load balancer.
+  returned: success
+  type: str
+  sample: a5396f25-945f-4968-854e-8400af7bee97
+name:
+  description: Name of the internal load balancer.
+  returned: success
+  type: str
+  sample: web-ilb
+algorithm:
+  description: Load balancing algorithm used.
+  returned: success
+  type: str
+  sample: roundrobin
+source_port:
+  description: Source port the internal load balancer listens on.
+  returned: success
+  type: int
+  sample: 80
+instance_port:
+  description: Port on the balanced instances traffic is forwarded to.
+  returned: success
+  type: int
+  sample: 8080
+source_ip:
+  description: Source IP address of the internal load balancer.
+  returned: success
+  type: str
+  sample: 10.10.1.247
+source_ip_network_id:
+  description: UUID of the network the source IP address is taken from.
+  returned: success
+  type: str
+  sample: e83f0010-4e08-493f-acc8-f5205d83b30d
+network_id:
+  description: UUID of the network the internal load balancer balances traffic to.
+  returned: success
+  type: str
+  sample: e83f0010-4e08-493f-acc8-f5205d83b30d
+network:
+  description: Name of the network the internal load balancer balances traffic to.
+  returned: success
+  type: str
+  sample: web-tier
+for_display:
+  description: Whether the internal load balancer is displayed to the regular user.
+  returned: when running as an admin account
+  type: bool
+  sample: true
+state:
+  description: State of the internal load balancer rule.
+  returned: success
+  type: str
+  sample: Active
+zone:
+  description: Name of the zone the internal load balancer belongs to.
+  returned: success
+  type: str
+  sample: zone01
+project:
+  description: Name of the project the internal load balancer is related to.
+  returned: when available
+  type: str
+  sample: Production
+account:
+  description: Account the internal load balancer is related to.
+  returned: when available
+  type: str
+  sample: example-account
+domain:
+  description: Domain the internal load balancer is related to.
+  returned: when available
+  type: str
+  sample: ROOT
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
+
+# The API only accepts this scheme, see CreateApplicationLoadBalancerCmd. It is deliberately
+# not exposed as an option, as that would imply a Public option the API rejects.
+LB_SCHEME = "Internal"
+
+
+class AnsibleCloudStackLbInternal(AnsibleCloudStack):
+    """AnsibleCloudStackLbInternal"""
+
+    def __init__(self, module):
+        super(AnsibleCloudStackLbInternal, self).__init__(module)
+        self.lb_internal = None
+        self.source_ip_network = None
+        self.returns = {
+            "algorithm": "algorithm",
+            "fordisplay": "for_display",
+            "networkid": "network_id",
+            "sourceipaddress": "source_ip",
+            "sourceipaddressnetworkid": "source_ip_network_id",
+        }
+        self.returns_to_int = {
+            "instanceport": "instance_port",
+            "sourceport": "source_port",
+        }
+
+    def get_source_ip_network(self, key=None):
+        """Return the network the source IP is taken from, defaults to the LB network."""
+        source_ip_network = self.module.params.get("source_ip_network")
+        if not source_ip_network:
+            return self.get_network(key=key)
+
+        if self.source_ip_network:
+            return self._get_by_key(key, self.source_ip_network)
+
+        args = {
+            "account": self.get_account(key="name"),
+            "domainid": self.get_domain(key="id"),
+            "projectid": self.get_project(key="id"),
+            "vpcid": self.get_vpc(key="id"),
+            "zoneid": self.get_zone(key="id"),
+            "fetch_list": True,
+        }
+        networks = self.query_api("listNetworks", **args)
+        if networks:
+            for n in networks:
+                if source_ip_network in [n["displaytext"], n["name"], n["id"]]:
+                    self.source_ip_network = n
+                    return self._get_by_key(key, self.source_ip_network)
+        self.fail_json(msg="Network '%s' not found" % source_ip_network)
+
+    def _get_common_args(self):
+        args = {
+            "account": self.get_account(key="name"),
+            "domainid": self.get_domain(key="id"),
+            "name": self.module.params.get("name"),
+            "networkid": self.get_network(key="id"),
+            "projectid": self.get_project(key="id"),
+        }
+        return args
+
+    def get_lb_internal(self):
+        if self.lb_internal:
+            return self.lb_internal
+
+        args = self._get_common_args()
+        # The response carries no scheme, so it must be filtered on the query. This also
+        # ensures a public LB rule of the same name is never matched.
+        args["scheme"] = LB_SCHEME
+        args["fetch_list"] = True
+
+        # listLoadBalancers only returns rules with display=true unless fordisplay is passed
+        # explicitly: ListApplicationLoadBalancersCmd.getDisplay() falls back to a hardcoded
+        # true in BaseListAccountResourcesCmd, which searchForLoadBalancers then applies as a
+        # search parameter. Without the second pass, a load balancer created with
+        # for_display=false would be invisible here and we would create a duplicate.
+        for fordisplay in (None, False):
+            if fordisplay is None:
+                args.pop("fordisplay", None)
+            else:
+                args["fordisplay"] = fordisplay
+
+            lb_internals = self.query_api("listLoadBalancers", **args)
+            if lb_internals:
+                for lb_internal in lb_internals:
+                    if lb_internal["name"] == self.module.params.get("name"):
+                        self.lb_internal = lb_internal
+                        return self.lb_internal
+
+        return None
+
+    def _get_lb_rule(self, lb_internal):
+        """Return the first LB rule, which carries the ports."""
+        lb_rules = lb_internal.get("loadbalancerrule") or []
+        return lb_rules[0] if lb_rules else {}
+
+    def _get_immutable_diff(self, lb_internal):
+        """Return a list of human readable diffs of options which can not be updated."""
+        lb_rule = self._get_lb_rule(lb_internal)
+
+        # (module option, wanted value, current value)
+        candidates = [
+            ("source_port", self.module.params.get("source_port"), lb_rule.get("sourceport")),
+            ("instance_port", self.module.params.get("instance_port"), lb_rule.get("instanceport")),
+            ("algorithm", self.module.params.get("algorithm"), lb_internal.get("algorithm")),
+            ("source_ip", self.module.params.get("source_ip"), lb_internal.get("sourceipaddress")),
+            (
+                "source_ip_network",
+                self.get_source_ip_network(key="id") if self.module.params.get("source_ip_network") else None,
+                lb_internal.get("sourceipaddressnetworkid"),
+            ),
+        ]
+
+        diff = []
+        for option, wanted, current in candidates:
+            # Not given, nothing to compare against. Ports are enforced by required_if.
+            if wanted is None:
+                continue
+
+            if isinstance(wanted, int):
+                if current is None or int(current) != wanted:
+                    diff.append("%s (current: %s, wanted: %s)" % (option, current, wanted))
+            elif str(current).lower() != str(wanted).lower():
+                diff.append("%s (current: %s, wanted: %s)" % (option, current, wanted))
+
+        return diff
+
+    def _update_for_display(self, lb_internal):
+        for_display = self.module.params.get("for_display")
+        if for_display is None:
+            return lb_internal
+
+        # fordisplay is returned to admin accounts only, so drift can not be detected as a
+        # regular user. Warn rather than updating on every run.
+        if "fordisplay" not in lb_internal:
+            self.module.warn(
+                "Can not verify for_display: the API returns it to admin accounts only. "
+                "Leaving it unchanged on internal load balancer '%s'." % lb_internal["name"]
+            )
+            return lb_internal
+
+        if lb_internal["fordisplay"] == for_display:
+            return lb_internal
+
+        self.result["changed"] = True
+        self.result["diff"]["before"]["for_display"] = lb_internal["fordisplay"]
+        self.result["diff"]["after"]["for_display"] = for_display
+
+        if not self.module.check_mode:
+            args = {
+                "id": lb_internal["id"],
+                "fordisplay": for_display,
+            }
+            res = self.query_api("updateLoadBalancer", **args)
+            if self.module.params.get("poll_async"):
+                lb_internal = self.poll_job(res, "loadbalancer")
+
+        return lb_internal
+
+    def present_lb_internal(self):
+        lb_internal = self.get_lb_internal()
+
+        if lb_internal:
+            diff = self._get_immutable_diff(lb_internal)
+            if diff:
+                self.fail_json(
+                    msg="Internal load balancer '%s' exists but the following options can not be "
+                    "changed: %s. Use state=absent followed by state=present to recreate it."
+                    % (self.module.params.get("name"), ", ".join(diff))
+                )
+            lb_internal = self._update_for_display(lb_internal)
+        else:
+            self.result["changed"] = True
+            args = self._get_common_args()
+            args.update(
+                {
+                    "algorithm": self.module.params.get("algorithm"),
+                    "description": self.module.params.get("description"),
+                    "fordisplay": self.module.params.get("for_display"),
+                    "instanceport": self.module.params.get("instance_port"),
+                    "scheme": LB_SCHEME,
+                    "sourceipaddress": self.module.params.get("source_ip"),
+                    "sourceipaddressnetworkid": self.get_source_ip_network(key="id"),
+                    "sourceport": self.module.params.get("source_port"),
+                }
+            )
+
+            if not self.module.check_mode:
+                res = self.query_api("createLoadBalancer", **args)
+                if self.module.params.get("poll_async"):
+                    lb_internal = self.poll_job(res, "loadbalancer")
+
+        self.lb_internal = lb_internal
+        return lb_internal
+
+    def absent_lb_internal(self):
+        lb_internal = self.get_lb_internal()
+        if lb_internal:
+            self.result["changed"] = True
+            if not self.module.check_mode:
+                res = self.query_api("deleteLoadBalancer", id=lb_internal["id"])
+                if self.module.params.get("poll_async"):
+                    self.poll_job(res)
+        return lb_internal
+
+    def get_result(self, resource):
+        if resource:
+            # The ports live inside loadbalancerrule[], lift them so they can be returned.
+            lb_rule = self._get_lb_rule(resource)
+            if lb_rule:
+                resource = dict(resource)
+                resource["sourceport"] = lb_rule.get("sourceport")
+                resource["instanceport"] = lb_rule.get("instanceport")
+                resource["state"] = lb_rule.get("state")
+        return super(AnsibleCloudStackLbInternal, self).get_result(resource)
+
+
+def main():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(
+        dict(
+            account=dict(type="str"),
+            algorithm=dict(type="str", choices=["source", "roundrobin", "leastconn"], default="source"),
+            description=dict(type="str"),
+            domain=dict(type="str"),
+            for_display=dict(type="bool"),
+            instance_port=dict(type="int"),
+            name=dict(type="str", required=True),
+            network=dict(type="str", required=True),
+            poll_async=dict(type="bool", default=True),
+            project=dict(type="str"),
+            source_ip=dict(type="str"),
+            source_ip_network=dict(type="str"),
+            source_port=dict(type="int"),
+            state=dict(type="str", choices=["present", "absent"], default="present"),
+            vpc=dict(type="str"),
+            zone=dict(type="str", required=True),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=cs_required_together(),
+        required_if=[
+            ("state", "present", ["source_port", "instance_port"]),
+        ],
+        supports_check_mode=True,
+    )
+
+    acs_lb_internal = AnsibleCloudStackLbInternal(module)
+
+    state = module.params.get("state")
+    if state == "absent":
+        lb_internal = acs_lb_internal.absent_lb_internal()
+    else:
+        lb_internal = acs_lb_internal.present_lb_internal()
+
+    result = acs_lb_internal.get_result(lb_internal)
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/lb_internal.py
+++ b/plugins/modules/lb_internal.py
@@ -81,7 +81,8 @@ options:
     description:
       - Whether to delete and recreate the internal load balancer when an option which can not
         be updated differs from the existing one.
-      - Without it, such a difference fails the task instead.
+      - Without it, such a difference only produces a warning and the load balancer is left
+        unchanged.
       - Only considered on I(state=present). See the notes below for the consequences.
     type: bool
     default: false
@@ -119,10 +120,10 @@ options:
     default: true
 notes:
   - The CloudStack API only allows I(for_display) to be updated on an existing internal
-    load balancer. When any other option differs, this module fails and names the differing
-    options, so a live load balancer is never torn down by an unrelated playbook run. Set
-    I(force=true) to delete and recreate it instead, or use I(state=absent) followed by
-    I(state=present).
+    load balancer. When any other option differs, this module leaves the load balancer as it
+    is and warns, naming the differing options, so a live load balancer is never torn down by
+    an unrelated playbook run. Set I(force=true) to delete and recreate it instead, or use
+    I(state=absent) followed by I(state=present).
   - I(force=true) only acts when an option actually differs, so it stays idempotent and can
     safely be driven by a playbook variable.
   - Recreating drops every member assigned to the load balancer. Re-apply them with
@@ -481,8 +482,10 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
             elif self.module.params.get("force"):
                 lb_internal = self._recreate_lb_internal(lb_internal, diff)
             else:
-                self.fail_json(
-                    msg="Internal load balancer '%s' exists but the following options can not be "
+                # Warn rather than fail, consistent with the other modules of this collection:
+                # a failed task aborts the play and a rerun would not trigger handlers again.
+                self.module.warn(
+                    "Internal load balancer '%s' exists but the following options can not be "
                     "changed: %s. Use force=true to delete and recreate it, or state=absent "
                     "followed by state=present."
                     % (
@@ -490,6 +493,7 @@ class AnsibleCloudStackLbInternal(AnsibleCloudStack):
                         ", ".join("%s (current: %s, wanted: %s)" % d for d in diff),
                     )
                 )
+                lb_internal = self._update_for_display(lb_internal)
         else:
             self.result["changed"] = True
             lb_internal = self._create_lb_internal()

--- a/plugins/modules/lb_internal_member.py
+++ b/plugins/modules/lb_internal_member.py
@@ -1,0 +1,361 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+---
+module: lb_internal_member
+short_description: Manages internal load balancer members on Apache CloudStack based clouds.
+description:
+    - Add and remove instances to and from an internal load balancer created by
+      M(ngine_io.cloudstack.lb_internal).
+    - For public load balancer rules use M(ngine_io.cloudstack.lb_rule_member) instead.
+author: René Moser (@resmo)
+options:
+  name:
+    description:
+      - Name of the internal load balancer the instances are assigned to.
+    type: str
+    required: true
+  network:
+    description:
+      - Name of the VPC tier the internal load balancer balances traffic to.
+    type: str
+    required: true
+  vms:
+    description:
+      - List of instance names the internal load balancer balances traffic to.
+    type: list
+    elements: str
+    required: true
+    aliases: [ vm ]
+  vpc:
+    description:
+      - Name of the VPC the I(network) belongs to.
+    type: str
+  zone:
+    description:
+      - Name of the zone the internal load balancer belongs to.
+    type: str
+    required: true
+  domain:
+    description:
+      - Domain the internal load balancer is related to.
+    type: str
+  account:
+    description:
+      - Account the internal load balancer is related to.
+    type: str
+  project:
+    description:
+      - Name of the project the internal load balancer is related to.
+    type: str
+  state:
+    description:
+      - Whether the instances should be assigned to or removed from the internal load balancer.
+    type: str
+    default: present
+    choices: [ present, absent ]
+  poll_async:
+    description:
+      - Poll async jobs until job has finished.
+    type: bool
+    default: true
+notes:
+  - The instances must be members of the same VPC tier the internal load balancer balances
+    traffic to.
+  - The C(InternalLbVm) system instance is only deployed by CloudStack once the first member
+    has been assigned. It can be managed using M(ngine_io.cloudstack.internal_lb_vm).
+extends_documentation_fragment:
+- ngine_io.cloudstack.cloudstack
+"""
+
+EXAMPLES = """
+- name: Ensure instances are assigned to the internal load balancer
+  ngine_io.cloudstack.lb_internal_member:
+    name: web-ilb
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    vms:
+      - web-01
+      - web-02
+
+- name: Ensure an instance is removed from the internal load balancer
+  ngine_io.cloudstack.lb_internal_member:
+    name: web-ilb
+    vpc: my-vpc
+    network: web-tier
+    zone: zone01
+    vm: web-02
+    state: absent
+"""
+
+RETURN = """
+---
+id:
+  description: UUID of the internal load balancer.
+  returned: success
+  type: str
+  sample: a5396f25-945f-4968-854e-8400af7bee97
+name:
+  description: Name of the internal load balancer.
+  returned: success
+  type: str
+  sample: web-ilb
+algorithm:
+  description: Load balancing algorithm used.
+  returned: success
+  type: str
+  sample: roundrobin
+source_port:
+  description: Source port the internal load balancer listens on.
+  returned: success
+  type: int
+  sample: 80
+instance_port:
+  description: Port on the balanced instances traffic is forwarded to.
+  returned: success
+  type: int
+  sample: 8080
+source_ip:
+  description: Source IP address of the internal load balancer.
+  returned: success
+  type: str
+  sample: 10.10.1.247
+network_id:
+  description: UUID of the network the internal load balancer balances traffic to.
+  returned: success
+  type: str
+  sample: e83f0010-4e08-493f-acc8-f5205d83b30d
+vms:
+  description: List of instance names assigned to the internal load balancer.
+  returned: success
+  type: list
+  sample: [ web-01, web-02 ]
+zone:
+  description: Name of the zone the internal load balancer belongs to.
+  returned: success
+  type: str
+  sample: zone01
+account:
+  description: Account the internal load balancer is related to.
+  returned: when available
+  type: str
+  sample: example-account
+domain:
+  description: Domain the internal load balancer is related to.
+  returned: when available
+  type: str
+  sample: ROOT
+project:
+  description: Name of the project the internal load balancer is related to.
+  returned: when available
+  type: str
+  sample: Production
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
+
+LB_SCHEME = "Internal"
+
+
+class AnsibleCloudStackLbInternalMember(AnsibleCloudStack):
+    """AnsibleCloudStackLbInternalMember"""
+
+    def __init__(self, module):
+        super(AnsibleCloudStackLbInternalMember, self).__init__(module)
+        self.lb_internal = None
+        self.vms = None
+        self.returns = {
+            "algorithm": "algorithm",
+            "networkid": "network_id",
+            "sourceipaddress": "source_ip",
+            "sourceipaddressnetworkid": "source_ip_network_id",
+        }
+        self.returns_to_int = {
+            "instanceport": "instance_port",
+            "sourceport": "source_port",
+        }
+
+    def _get_common_args(self):
+        args = {
+            "account": self.get_account(key="name"),
+            "domainid": self.get_domain(key="id"),
+            "name": self.module.params.get("name"),
+            "networkid": self.get_network(key="id"),
+            "projectid": self.get_project(key="id"),
+        }
+        return args
+
+    def get_lb_internal(self):
+        if self.lb_internal:
+            return self.lb_internal
+
+        args = self._get_common_args()
+        args["scheme"] = LB_SCHEME
+        args["fetch_list"] = True
+
+        # listLoadBalancers only returns rules with display=true unless fordisplay is passed
+        # explicitly, see ListApplicationLoadBalancersCmd.getDisplay(). Without the second
+        # pass, a load balancer created with for_display=false would not be found here.
+        for fordisplay in (None, False):
+            if fordisplay is None:
+                args.pop("fordisplay", None)
+            else:
+                args["fordisplay"] = fordisplay
+
+            lb_internals = self.query_api("listLoadBalancers", **args)
+            if lb_internals:
+                for lb_internal in lb_internals:
+                    if lb_internal["name"] == self.module.params.get("name"):
+                        self.lb_internal = lb_internal
+                        return self.lb_internal
+
+        return None
+
+    def _get_vms(self):
+        """Return the instances of the load balanced network."""
+        if self.vms is None:
+            args = {
+                "account": self.get_account(key="name"),
+                "domainid": self.get_domain(key="id"),
+                "networkid": self.get_network(key="id"),
+                "projectid": self.get_project(key="id"),
+                "fetch_list": True,
+            }
+            self.vms = self.query_api("listVirtualMachines", **args) or []
+        return self.vms
+
+    def _get_member_ids(self, lb_internal):
+        """Return the UUIDs of the instances assigned to the load balancer.
+
+        Matching is done on UUID, never on name: loadbalancerinstance[] reports the internal
+        instance name (i-2-10-QA), not the name the user deployed the instance with.
+        """
+        return set(vm["id"] for vm in lb_internal.get("loadbalancerinstance") or [])
+
+    def _get_member_names(self, lb_internal):
+        """Return the user facing names of the instances assigned to the load balancer."""
+        member_ids = self._get_member_ids(lb_internal)
+        names = []
+        for vm in self._get_vms():
+            if vm["id"] in member_ids:
+                names.append(vm["name"])
+        return sorted(names)
+
+    def _ensure_members(self, operation):
+        lb_internal = self.get_lb_internal()
+        if not lb_internal:
+            self.fail_json(msg="Internal load balancer not found: %s" % self.module.params.get("name"))
+
+        # Resolve the wanted instances to UUIDs. Only instances of the load balanced network
+        # can be assigned, so a name not found here would fail in the API anyway.
+        by_name = dict()
+        for vm in self._get_vms():
+            by_name[vm["name"]] = vm["id"]
+            by_name[vm["id"]] = vm["id"]
+
+        wanted_ids = []
+        for name in self.module.params.get("vms"):
+            if name not in by_name:
+                self.fail_json(msg="Instance not found in network %s: %s" % (self.module.params.get("network"), name))
+            wanted_ids.append(by_name[name])
+
+        existing_ids = self._get_member_ids(lb_internal)
+
+        if operation == "add":
+            api = "assignToLoadBalancerRule"
+            to_change_ids = [i for i in wanted_ids if i not in existing_ids]
+            after_ids = existing_ids | set(wanted_ids)
+        else:
+            api = "removeFromLoadBalancerRule"
+            to_change_ids = [i for i in wanted_ids if i in existing_ids]
+            after_ids = existing_ids - set(wanted_ids)
+
+        if not to_change_ids:
+            return lb_internal
+
+        id_to_name = dict((vm["id"], vm["name"]) for vm in self._get_vms())
+        self.result["changed"] = True
+        self.result["diff"]["before"]["vms"] = sorted(id_to_name.get(i, i) for i in existing_ids)
+        self.result["diff"]["after"]["vms"] = sorted(id_to_name.get(i, i) for i in after_ids)
+
+        if not self.module.check_mode:
+            res = self.query_api(api, id=lb_internal["id"], virtualmachineids=to_change_ids)
+            if self.module.params.get("poll_async"):
+                self.poll_job(res)
+                # Re-read so the returned members reflect the change.
+                self.lb_internal = None
+                lb_internal = self.get_lb_internal()
+
+        return lb_internal
+
+    def add_members(self):
+        return self._ensure_members("add")
+
+    def remove_members(self):
+        return self._ensure_members("remove")
+
+    def get_result(self, resource):
+        if resource:
+            lb_rules = resource.get("loadbalancerrule") or []
+            if lb_rules:
+                resource = dict(resource)
+                resource["sourceport"] = lb_rules[0].get("sourceport")
+                resource["instanceport"] = lb_rules[0].get("instanceport")
+                resource["state"] = lb_rules[0].get("state")
+
+        super(AnsibleCloudStackLbInternalMember, self).get_result(resource)
+
+        if resource:
+            self.result["vms"] = self._get_member_names(resource)
+        return self.result
+
+
+def main():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(
+        dict(
+            account=dict(type="str"),
+            domain=dict(type="str"),
+            name=dict(type="str", required=True),
+            network=dict(type="str", required=True),
+            poll_async=dict(type="bool", default=True),
+            project=dict(type="str"),
+            state=dict(type="str", choices=["present", "absent"], default="present"),
+            vms=dict(type="list", elements="str", required=True, aliases=["vm"]),
+            vpc=dict(type="str"),
+            zone=dict(type="str", required=True),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=cs_required_together(),
+        supports_check_mode=True,
+    )
+
+    acs_lb_internal_member = AnsibleCloudStackLbInternalMember(module)
+
+    state = module.params.get("state")
+    if state == "absent":
+        lb_internal = acs_lb_internal_member.remove_members()
+    else:
+        lb_internal = acs_lb_internal_member.add_members()
+
+    result = acs_lb_internal_member.get_result(lb_internal)
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/lb_internal_member.py
+++ b/plugins/modules/lb_internal_member.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
+# Copyright (c) 2026, Mitch Drage <mitch@lsnetworks.com.au>
 # Copyright (c) 2026, René Moser <mail@renemoser.net>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -17,7 +18,7 @@ description:
     - Add and remove instances to and from an internal load balancer created by
       M(ngine_io.cloudstack.lb_internal).
     - For public load balancer rules use M(ngine_io.cloudstack.lb_rule_member) instead.
-author: René Moser (@resmo)
+author: Mitch Drage (@MitchDrage)
 options:
   name:
     description:

--- a/tests/integration/targets/internal_lb_vm/aliases
+++ b/tests/integration/targets/internal_lb_vm/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+cs/group1

--- a/tests/integration/targets/internal_lb_vm/defaults/main.yml
+++ b/tests/integration/targets/internal_lb_vm/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+cs_lb_internal_vpc_offering: Default VPC offering
+cs_lb_internal_network_offering: DefaultIsolatedNetworkOfferingForVpcNetworksWithInternalLB

--- a/tests/integration/targets/internal_lb_vm/meta/main.yml
+++ b/tests/integration/targets/internal_lb_vm/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/tests/integration/targets/internal_lb_vm/tasks/main.yml
+++ b/tests/integration/targets/internal_lb_vm/tasks/main.yml
@@ -1,0 +1,250 @@
+---
+- name: setup vpc
+  ngine_io.cloudstack.vpc:
+    name: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    display_text: "{{ cs_resource_prefix }}_display_text"
+    cidr: 10.13.0.0/16
+    vpc_offering: "{{ cs_lb_internal_vpc_offering }}"
+    zone: "{{ cs_common_zone_adv }}"
+  register: vpc
+- name: verify setup vpc
+  assert:
+    that:
+      - vpc is successful
+
+- name: setup vpc tier with internal lb support
+  ngine_io.cloudstack.network:
+    name: "{{ cs_resource_prefix }}_ilbvm_tier"
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network_offering: "{{ cs_lb_internal_network_offering }}"
+    gateway: 10.13.1.1
+    netmask: 255.255.255.0
+    zone: "{{ cs_common_zone_adv }}"
+  register: tier
+- name: verify setup vpc tier with internal lb support
+  assert:
+    that:
+      - tier is successful
+
+- name: test fail no internal lb instance deployed yet
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+  ignore_errors: true
+  register: ilb_vm
+- name: verify test fail no internal lb instance deployed yet
+  assert:
+    that:
+      - ilb_vm is failed
+      - "'Internal load balancer instance not found' in ilb_vm.msg"
+
+- name: setup internal lb
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_ilbvm_lb"
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+  register: lb
+- name: verify setup internal lb
+  assert:
+    that:
+      - lb is successful
+
+- name: setup instance in the tier
+  ngine_io.cloudstack.instance:
+    name: "{{ cs_resource_prefix }}-ilbvm-vm"
+    template: "{{ cs_common_template }}"
+    service_offering: "{{ cs_common_service_offering }}"
+    networks:
+      - "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+  register: instance
+- name: verify setup instance in the tier
+  assert:
+    that:
+      - instance is successful
+
+# CloudStack only deploys the InternalLbVm once the first member is assigned.
+- name: setup internal lb member
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_ilbvm_lb"
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-ilbvm-vm"
+  register: member
+- name: verify setup internal lb member
+  assert:
+    that:
+      - member is changed
+
+- name: test fail missing required args for internal lb vm
+  ngine_io.cloudstack.internal_lb_vm:
+  ignore_errors: true
+  register: ilb_vm
+- name: verify test fail missing required args for internal lb vm
+  assert:
+    that:
+      - ilb_vm is failed
+      - "ilb_vm.msg.startswith('missing required arguments: ')"
+
+- name: test fail no selector given for internal lb vm
+  ngine_io.cloudstack.internal_lb_vm:
+    zone: "{{ cs_common_zone_adv }}"
+  ignore_errors: true
+  register: ilb_vm
+- name: verify test fail no selector given for internal lb vm
+  assert:
+    that:
+      - ilb_vm is failed
+      - "'one of the following is required: name, network, vpc' in ilb_vm.msg"
+
+- name: test internal lb vm is already started
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: started
+  register: ilb_vm
+- name: verify test internal lb vm is already started
+  assert:
+    that:
+      - ilb_vm is not changed
+      - ilb_vm.state == 'Running'
+      - ilb_vm.network_id == tier.id
+
+- name: test stop internal lb vm in check mode
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: stopped
+  check_mode: true
+  register: ilb_vm
+- name: verify test stop internal lb vm in check mode
+  assert:
+    that:
+      - ilb_vm is changed
+      - ilb_vm.state == 'Running'
+
+- name: test stop internal lb vm
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: stopped
+  register: ilb_vm
+- name: verify test stop internal lb vm
+  assert:
+    that:
+      - ilb_vm is changed
+      - ilb_vm.state == 'Stopped'
+
+- name: test stop internal lb vm idempotence
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: stopped
+  register: ilb_vm
+- name: verify test stop internal lb vm idempotence
+  assert:
+    that:
+      - ilb_vm is not changed
+      - ilb_vm.state == 'Stopped'
+
+- name: test start internal lb vm by name
+  ngine_io.cloudstack.internal_lb_vm:
+    name: "{{ ilb_vm.name }}"
+    zone: "{{ cs_common_zone_adv }}"
+    state: started
+  register: ilb_vm_started
+- name: verify test start internal lb vm by name
+  assert:
+    that:
+      - ilb_vm_started is changed
+      - ilb_vm_started.state == 'Running'
+      - ilb_vm_started.id == ilb_vm.id
+
+- name: test start internal lb vm idempotence
+  ngine_io.cloudstack.internal_lb_vm:
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: started
+  register: ilb_vm
+- name: verify test start internal lb vm idempotence
+  assert:
+    that:
+      - ilb_vm is not changed
+      - ilb_vm.state == 'Running'
+
+- name: cleanup internal lb member
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_ilbvm_lb"
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-ilbvm-vm"
+    state: absent
+  register: member
+- name: verify cleanup internal lb member
+  assert:
+    that:
+      - member is successful
+
+- name: cleanup instance
+  ngine_io.cloudstack.instance:
+    name: "{{ cs_resource_prefix }}-ilbvm-vm"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: instance
+- name: verify cleanup instance
+  assert:
+    that:
+      - instance is successful
+
+- name: cleanup internal lb
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_ilbvm_lb"
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    network: "{{ cs_resource_prefix }}_ilbvm_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: lb
+- name: verify cleanup internal lb
+  assert:
+    that:
+      - lb is successful
+
+# The InternalLbVm is garbage collected asynchronously once the last member is gone, and the
+# tier can not be deleted while it is still attached.
+- name: cleanup vpc tier
+  ngine_io.cloudstack.network:
+    name: "{{ cs_resource_prefix }}_ilbvm_tier"
+    vpc: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: tier
+  until: tier is successful
+  retries: 20
+  delay: 5
+- name: verify cleanup vpc tier
+  assert:
+    that:
+      - tier is successful
+
+- name: cleanup vpc
+  ngine_io.cloudstack.vpc:
+    name: "{{ cs_resource_prefix }}_ilbvm_vpc"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: vpc
+- name: verify cleanup vpc
+  assert:
+    that:
+      - vpc is successful

--- a/tests/integration/targets/lb_internal/aliases
+++ b/tests/integration/targets/lb_internal/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+cs/group2

--- a/tests/integration/targets/lb_internal/defaults/main.yml
+++ b/tests/integration/targets/lb_internal/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# An internal load balancer requires a VPC offering which supports the Lb service with the
+# InternalLbVm provider, and a tier network offering which uses it. Both are shipped as
+# defaults by CloudStack.
+cs_lb_internal_vpc_offering: Default VPC offering
+cs_lb_internal_network_offering: DefaultIsolatedNetworkOfferingForVpcNetworksWithInternalLB

--- a/tests/integration/targets/lb_internal/meta/main.yml
+++ b/tests/integration/targets/lb_internal/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/tests/integration/targets/lb_internal/tasks/main.yml
+++ b/tests/integration/targets/lb_internal/tasks/main.yml
@@ -165,7 +165,7 @@
       - lb_internal_no_algo_force.id == lb_internal.id
       - lb_internal_no_algo_force.algorithm == "roundrobin"
 
-- name: test internal lb fails on immutable option change
+- name: test internal lb warns on immutable option change
   ngine_io.cloudstack.lb_internal:
     name: "{{ cs_resource_prefix }}_lb"
     vpc: "{{ cs_resource_prefix }}_vpc"
@@ -174,18 +174,18 @@
     source_port: 8081
     instance_port: 8080
     algorithm: leastconn
-  ignore_errors: true
   register: lb_internal_drift
-- name: verify test internal lb fails on immutable option change
+- name: verify test internal lb warns on immutable option change
   assert:
     that:
-      - lb_internal_drift is failed
-      - "'can not be changed' in lb_internal_drift.msg"
-      - "'source_port' in lb_internal_drift.msg"
-      - "'algorithm' in lb_internal_drift.msg"
-      - "'instance_port' not in lb_internal_drift.msg"
+      - lb_internal_drift is not changed
+      - lb_internal_drift.id == lb_internal.id
+      - "'can not be changed' in (lb_internal_drift.warnings | default([]) | join(' '))"
+      - "'source_port' in (lb_internal_drift.warnings | default([]) | join(' '))"
+      - "'algorithm' in (lb_internal_drift.warnings | default([]) | join(' '))"
+      - "'instance_port' not in (lb_internal_drift.warnings | default([]) | join(' '))"
 
-- name: verify internal lb still exists after failed immutable option change
+- name: verify internal lb is untouched after the immutable option warning
   ngine_io.cloudstack.lb_internal:
     name: "{{ cs_resource_prefix }}_lb"
     vpc: "{{ cs_resource_prefix }}_vpc"
@@ -195,7 +195,7 @@
     instance_port: 8080
     algorithm: roundrobin
   register: lb_internal_survived
-- name: verify internal lb still exists after failed immutable option change
+- name: verify internal lb is untouched after the immutable option warning
   assert:
     that:
       - lb_internal_survived is not changed

--- a/tests/integration/targets/lb_internal/tasks/main.yml
+++ b/tests/integration/targets/lb_internal/tasks/main.yml
@@ -201,6 +201,61 @@
     that:
       - lb_internal_display_idem is not changed
 
+- name: test internal lb force recreate in check mode
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 8081
+    instance_port: 8080
+    algorithm: roundrobin
+    force: true
+  check_mode: true
+  register: lb_internal_force
+- name: verify test internal lb force recreate in check mode
+  assert:
+    that:
+      - lb_internal_force is changed
+      - lb_internal_force.id == lb_internal.id
+      - lb_internal_force.source_port == 80
+
+- name: test internal lb force recreate
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 8081
+    instance_port: 8080
+    algorithm: roundrobin
+    force: true
+  register: lb_internal_force
+- name: verify test internal lb force recreate
+  assert:
+    that:
+      - lb_internal_force is changed
+      - lb_internal_force.id != lb_internal.id
+      - lb_internal_force.source_port == 8081
+      - lb_internal_force.instance_port == 8080
+
+- name: test internal lb force recreate idempotence
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 8081
+    instance_port: 8080
+    algorithm: roundrobin
+    force: true
+  register: lb_internal_force_idem
+- name: verify test internal lb force recreate idempotence
+  assert:
+    that:
+      - lb_internal_force_idem is not changed
+      - lb_internal_force_idem.id == lb_internal_force.id
+
 - name: test absent internal lb in check mode
   ngine_io.cloudstack.lb_internal:
     name: "{{ cs_resource_prefix }}_lb"

--- a/tests/integration/targets/lb_internal/tasks/main.yml
+++ b/tests/integration/targets/lb_internal/tasks/main.yml
@@ -132,6 +132,39 @@
       - lb_internal_idem.instance_port == 8080
       - lb_internal_idem.algorithm == "roundrobin"
 
+- name: test internal lb omitting algorithm is not a diff
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+  register: lb_internal_no_algo
+- name: verify test internal lb omitting algorithm is not a diff
+  assert:
+    that:
+      - lb_internal_no_algo is not changed
+      - lb_internal_no_algo.id == lb_internal.id
+      - lb_internal_no_algo.algorithm == "roundrobin"
+
+- name: test internal lb omitting algorithm does not recreate even with force
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    force: true
+  register: lb_internal_no_algo_force
+- name: verify test internal lb omitting algorithm does not recreate even with force
+  assert:
+    that:
+      - lb_internal_no_algo_force is not changed
+      - lb_internal_no_algo_force.id == lb_internal.id
+      - lb_internal_no_algo_force.algorithm == "roundrobin"
+
 - name: test internal lb fails on immutable option change
   ngine_io.cloudstack.lb_internal:
     name: "{{ cs_resource_prefix }}_lb"
@@ -238,6 +271,8 @@
       - lb_internal_force.id != lb_internal.id
       - lb_internal_force.source_port == 8081
       - lb_internal_force.instance_port == 8080
+      # the address is carried over, so consumers of the VIP keep working
+      - lb_internal_force.source_ip == lb_internal.source_ip
 
 - name: test internal lb force recreate idempotence
   ngine_io.cloudstack.lb_internal:

--- a/tests/integration/targets/lb_internal/tasks/main.yml
+++ b/tests/integration/targets/lb_internal/tasks/main.yml
@@ -1,0 +1,265 @@
+---
+- name: setup vpc
+  ngine_io.cloudstack.vpc:
+    name: "{{ cs_resource_prefix }}_vpc"
+    display_text: "{{ cs_resource_prefix }}_display_text"
+    cidr: 10.10.0.0/16
+    vpc_offering: "{{ cs_lb_internal_vpc_offering }}"
+    zone: "{{ cs_common_zone_adv }}"
+  register: vpc
+- name: verify setup vpc
+  assert:
+    that:
+      - vpc is successful
+
+- name: setup vpc tier with internal lb support
+  ngine_io.cloudstack.network:
+    name: "{{ cs_resource_prefix }}_tier"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network_offering: "{{ cs_lb_internal_network_offering }}"
+    gateway: 10.10.1.1
+    netmask: 255.255.255.0
+    zone: "{{ cs_common_zone_adv }}"
+  register: tier
+- name: verify setup vpc tier with internal lb support
+  assert:
+    that:
+      - tier is successful
+
+- name: setup internal lb absent
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: lb_internal
+- name: verify setup internal lb absent
+  assert:
+    that:
+      - lb_internal is successful
+
+- name: test fail missing required args for internal lb
+  ngine_io.cloudstack.lb_internal:
+  ignore_errors: true
+  register: lb_internal
+- name: verify test fail missing required args for internal lb
+  assert:
+    that:
+      - lb_internal is failed
+      - "lb_internal.msg.startswith('missing required arguments: ')"
+
+- name: test fail missing create params for internal lb
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+  ignore_errors: true
+  register: lb_internal
+- name: verify test fail missing create params for internal lb
+  assert:
+    that:
+      - lb_internal is failed
+      - 'lb_internal.msg == "state is present but all of the following are missing: source_port, instance_port"'
+
+- name: test create internal lb in check mode
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+  check_mode: true
+  register: lb_internal
+- name: verify test create internal lb in check mode
+  assert:
+    that:
+      - lb_internal is changed
+
+- name: verify internal lb was not created in check mode
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: lb_internal
+- name: verify internal lb was not created in check mode
+  assert:
+    that:
+      - lb_internal is not changed
+
+- name: test create internal lb
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+  register: lb_internal
+- name: verify test create internal lb
+  assert:
+    that:
+      - lb_internal is changed
+      - lb_internal.name == "{{ cs_resource_prefix }}_lb"
+      - lb_internal.source_port == 80
+      - lb_internal.instance_port == 8080
+      - lb_internal.algorithm == "roundrobin"
+      - lb_internal.source_ip is defined
+      - lb_internal.network_id == tier.id
+
+- name: test create internal lb idempotence
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+  register: lb_internal_idem
+- name: verify test create internal lb idempotence
+  assert:
+    that:
+      - lb_internal_idem is not changed
+      - lb_internal_idem.id == lb_internal.id
+      - lb_internal_idem.source_port == 80
+      - lb_internal_idem.instance_port == 8080
+      - lb_internal_idem.algorithm == "roundrobin"
+
+- name: test internal lb fails on immutable option change
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 8081
+    instance_port: 8080
+    algorithm: leastconn
+  ignore_errors: true
+  register: lb_internal_drift
+- name: verify test internal lb fails on immutable option change
+  assert:
+    that:
+      - lb_internal_drift is failed
+      - "'can not be changed' in lb_internal_drift.msg"
+      - "'source_port' in lb_internal_drift.msg"
+      - "'algorithm' in lb_internal_drift.msg"
+      - "'instance_port' not in lb_internal_drift.msg"
+
+- name: verify internal lb still exists after failed immutable option change
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+  register: lb_internal_survived
+- name: verify internal lb still exists after failed immutable option change
+  assert:
+    that:
+      - lb_internal_survived is not changed
+      - lb_internal_survived.id == lb_internal.id
+
+- name: test update internal lb for_display
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+    for_display: false
+  register: lb_internal_display
+- name: verify test update internal lb for_display
+  assert:
+    that:
+      - lb_internal_display is changed
+      - lb_internal_display.id == lb_internal.id
+
+- name: test update internal lb for_display idempotence
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+    for_display: false
+  register: lb_internal_display_idem
+- name: verify test update internal lb for_display idempotence
+  assert:
+    that:
+      - lb_internal_display_idem is not changed
+
+- name: test absent internal lb in check mode
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  check_mode: true
+  register: lb_internal
+- name: verify test absent internal lb in check mode
+  assert:
+    that:
+      - lb_internal is changed
+
+- name: test absent internal lb
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: lb_internal
+- name: verify test absent internal lb
+  assert:
+    that:
+      - lb_internal is changed
+
+- name: test absent internal lb idempotence
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_lb"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    network: "{{ cs_resource_prefix }}_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: lb_internal
+- name: verify test absent internal lb idempotence
+  assert:
+    that:
+      - lb_internal is not changed
+
+- name: cleanup vpc tier
+  ngine_io.cloudstack.network:
+    name: "{{ cs_resource_prefix }}_tier"
+    vpc: "{{ cs_resource_prefix }}_vpc"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: tier
+- name: verify cleanup vpc tier
+  assert:
+    that:
+      - tier is successful
+
+- name: cleanup vpc
+  ngine_io.cloudstack.vpc:
+    name: "{{ cs_resource_prefix }}_vpc"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: vpc
+- name: verify cleanup vpc
+  assert:
+    that:
+      - vpc is successful

--- a/tests/integration/targets/lb_internal_member/aliases
+++ b/tests/integration/targets/lb_internal_member/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+cs/group1

--- a/tests/integration/targets/lb_internal_member/defaults/main.yml
+++ b/tests/integration/targets/lb_internal_member/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+cs_lb_internal_vpc_offering: Default VPC offering
+cs_lb_internal_network_offering: DefaultIsolatedNetworkOfferingForVpcNetworksWithInternalLB

--- a/tests/integration/targets/lb_internal_member/meta/main.yml
+++ b/tests/integration/targets/lb_internal_member/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/tests/integration/targets/lb_internal_member/tasks/main.yml
+++ b/tests/integration/targets/lb_internal_member/tasks/main.yml
@@ -1,0 +1,223 @@
+---
+- name: setup vpc
+  ngine_io.cloudstack.vpc:
+    name: "{{ cs_resource_prefix }}_mem_vpc"
+    display_text: "{{ cs_resource_prefix }}_display_text"
+    cidr: 10.12.0.0/16
+    vpc_offering: "{{ cs_lb_internal_vpc_offering }}"
+    zone: "{{ cs_common_zone_adv }}"
+  register: vpc
+- name: verify setup vpc
+  assert:
+    that:
+      - vpc is successful
+
+- name: setup vpc tier with internal lb support
+  ngine_io.cloudstack.network:
+    name: "{{ cs_resource_prefix }}_mem_tier"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network_offering: "{{ cs_lb_internal_network_offering }}"
+    gateway: 10.12.1.1
+    netmask: 255.255.255.0
+    zone: "{{ cs_common_zone_adv }}"
+  register: tier
+- name: verify setup vpc tier with internal lb support
+  assert:
+    that:
+      - tier is successful
+
+- name: setup internal lb
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    source_port: 80
+    instance_port: 8080
+    algorithm: roundrobin
+  register: lb
+- name: verify setup internal lb
+  assert:
+    that:
+      - lb is successful
+
+- name: setup instance in the tier
+  ngine_io.cloudstack.instance:
+    name: "{{ cs_resource_prefix }}-mem-vm"
+    template: "{{ cs_common_template }}"
+    service_offering: "{{ cs_common_service_offering }}"
+    networks:
+      - "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+  register: instance
+- name: verify setup instance in the tier
+  assert:
+    that:
+      - instance is successful
+
+- name: test fail missing required args for internal lb member
+  ngine_io.cloudstack.lb_internal_member:
+  ignore_errors: true
+  register: member
+- name: verify test fail missing required args for internal lb member
+  assert:
+    that:
+      - member is failed
+      - "member.msg.startswith('missing required arguments: ')"
+
+- name: test fail unknown internal lb
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_mem_does_not_exist"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-mem-vm"
+  ignore_errors: true
+  register: member
+- name: verify test fail unknown internal lb
+  assert:
+    that:
+      - member is failed
+      - "'Internal load balancer not found' in member.msg"
+
+- name: test add member to internal lb in check mode
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-mem-vm"
+  check_mode: true
+  register: member
+- name: verify test add member to internal lb in check mode
+  assert:
+    that:
+      - member is changed
+      - member.vms == []
+
+- name: test add member to internal lb
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-mem-vm"
+  register: member
+- name: verify test add member to internal lb
+  assert:
+    that:
+      - member is changed
+      - member.id == lb.id
+      - instance.name in member.vms
+
+- name: test add member to internal lb idempotence
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-mem-vm"
+  register: member
+- name: verify test add member to internal lb idempotence
+  assert:
+    that:
+      - member is not changed
+      - instance.name in member.vms
+
+- name: test remove member from internal lb in check mode
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-mem-vm"
+    state: absent
+  check_mode: true
+  register: member
+- name: verify test remove member from internal lb in check mode
+  assert:
+    that:
+      - member is changed
+      - instance.name in member.vms
+
+- name: test remove member from internal lb
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-mem-vm"
+    state: absent
+  register: member
+- name: verify test remove member from internal lb
+  assert:
+    that:
+      - member is changed
+      - member.vms == []
+
+- name: test remove member from internal lb idempotence
+  ngine_io.cloudstack.lb_internal_member:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    vm: "{{ cs_resource_prefix }}-mem-vm"
+    state: absent
+  register: member
+- name: verify test remove member from internal lb idempotence
+  assert:
+    that:
+      - member is not changed
+      - member.vms == []
+
+- name: cleanup instance
+  ngine_io.cloudstack.instance:
+    name: "{{ cs_resource_prefix }}-mem-vm"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: instance
+- name: verify cleanup instance
+  assert:
+    that:
+      - instance is successful
+
+- name: cleanup internal lb
+  ngine_io.cloudstack.lb_internal:
+    name: "{{ cs_resource_prefix }}_mem_lb"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    network: "{{ cs_resource_prefix }}_mem_tier"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: lb
+- name: verify cleanup internal lb
+  assert:
+    that:
+      - lb is successful
+
+# The InternalLbVm is garbage collected asynchronously once the last member is gone, and the
+# tier can not be deleted while it is still attached.
+- name: cleanup vpc tier
+  ngine_io.cloudstack.network:
+    name: "{{ cs_resource_prefix }}_mem_tier"
+    vpc: "{{ cs_resource_prefix }}_mem_vpc"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: tier
+  until: tier is successful
+  retries: 20
+  delay: 5
+- name: verify cleanup vpc tier
+  assert:
+    that:
+      - tier is successful
+
+- name: cleanup vpc
+  ngine_io.cloudstack.vpc:
+    name: "{{ cs_resource_prefix }}_mem_vpc"
+    zone: "{{ cs_common_zone_adv }}"
+    state: absent
+  register: vpc
+- name: verify cleanup vpc
+  assert:
+    that:
+      - vpc is successful


### PR DESCRIPTION
New modules for internal LB.

- `lb_internal` - create/update/delete the internal LB
- `lb_internal_member` - assign and remove instances
- `internal_lb_vm` - start/stop the InternalLbVm system instance (admin-only APIs)

Integration test targets for all three. Tested against the cloudstack-test-container:1.7.0
simulator CI uses (4.18.1), and against a live CloudStack 4.22.1 cloud.

Two API behaviours worth mentioning, both handled in the modules:

- `listLoadBalancers` only returns rules with `display=true` (the default) unless `fordisplay`
  is passed explicitly. A name lookup therefore needs a second pass with `fordisplay=false`,
  otherwise `for_display: false` hides the LB and the next run creates a duplicate.
- `loadbalancerinstance[].name` is the internal instance name (i-2-10-QA), not the deployed
  name, so membership is matched on UUID.

`version_added` is unset - just add whichever release you're targeting.

Fixes #182